### PR TITLE
Add PR and Issue feed screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 bin/
 .build/
-gitctl-backend
+/gitctl-backend

--- a/cmd/gitctl-backend/main.go
+++ b/cmd/gitctl-backend/main.go
@@ -45,19 +45,25 @@ func main() {
 		log.Fatalf("Failed to chmod socket: %v", err)
 	}
 
-	// Set up storage and controller.
+	// Set up storage and controllers.
 	store := memorystorage.New()
 	githubClient := github.NewClient()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start the controller to poll GitHub and populate storage.
-	ctrl := controller.NewGitRepoController(githubClient, store, *username, *syncInterval)
-	go ctrl.Run(ctx)
+	// Start the controllers to poll GitHub and populate storage.
+	repoCtrl := controller.NewGitRepoController(githubClient, store, *username, *syncInterval)
+	go repoCtrl.Run(ctx)
+
+	prCtrl := controller.NewPullRequestController(githubClient, store, *username, *syncInterval)
+	go prCtrl.Run(ctx)
+
+	issueCtrl := controller.NewIssueController(githubClient, store, *username, *syncInterval)
+	go issueCtrl.Run(ctx)
 
 	// Create the API handler that reads from storage.
-	handler := backend.NewServer(store)
+	handler := backend.NewServer(store, store, store)
 
 	// Start Unix socket server.
 	unixServer := &http.Server{Handler: handler}

--- a/cmd/gitctl-macos/ContentView.swift
+++ b/cmd/gitctl-macos/ContentView.swift
@@ -1,6 +1,202 @@
 import SwiftUI
 
+enum SidebarItem: String, CaseIterable, Identifiable {
+    case feed = "Feed"
+    case assigned = "Assigned"
+    case repos = "Repositories"
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .feed: return "arrow.up.circle"
+        case .assigned: return "person.circle"
+        case .repos: return "folder"
+        }
+    }
+}
+
 struct ContentView: View {
+    @State private var selection: SidebarItem? = .feed
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selection) {
+                ForEach(SidebarItem.allCases) { item in
+                    NavigationLink(value: item) {
+                        Label(item.rawValue, systemImage: item.systemImage)
+                    }
+                }
+            }
+            .navigationTitle("gitctl")
+        } detail: {
+            switch selection {
+            case .feed:
+                FeedView()
+            case .assigned:
+                AssignedView()
+            case .repos:
+                ReposView()
+            case nil:
+                Text("Select a section")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Feed View (Outbound PRs)
+
+struct FeedView: View {
+    @State private var prs: [PullRequest] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var searchText = ""
+
+    private let client = GitCtlClient()
+    private let username = "justinsb"
+
+    var filteredPRs: [PullRequest] {
+        if searchText.isEmpty { return prs }
+        return prs.filter { pr in
+            let title = pr.spec?.title ?? ""
+            let repo = pr.status?.repo ?? ""
+            return title.localizedCaseInsensitiveContains(searchText)
+                || repo.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading feed...")
+            } else if let error = errorMessage {
+                ErrorView(message: error) { Task { await load() } }
+            } else {
+                List(filteredPRs) { pr in
+                    PRRow(pr: pr)
+                }
+            }
+        }
+        .navigationTitle("Feed")
+        .searchable(text: $searchText, prompt: "Filter PRs")
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: { Task { await load() } }) {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help("Refresh")
+            }
+        }
+        .task { await load() }
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            prs = try await client.listPullRequests(username: username, scope: "outbound")
+            isLoading = false
+        } catch {
+            errorMessage = "Failed to load feed: \(error.localizedDescription)\n\nMake sure the backend is running:\n  go run cmd/gitctl-backend/main.go"
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - Assigned View (PRs + Issues assigned to me)
+
+struct AssignedView: View {
+    @State private var prs: [PullRequest] = []
+    @State private var issues: [Issue] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var searchText = ""
+
+    private let client = GitCtlClient()
+    private let username = "justinsb"
+
+    var filteredPRs: [PullRequest] {
+        if searchText.isEmpty { return prs }
+        return prs.filter { pr in
+            let title = pr.spec?.title ?? ""
+            let repo = pr.status?.repo ?? ""
+            return title.localizedCaseInsensitiveContains(searchText)
+                || repo.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var filteredIssues: [Issue] {
+        if searchText.isEmpty { return issues }
+        return issues.filter { issue in
+            let title = issue.spec?.title ?? ""
+            let repo = issue.status?.repo ?? ""
+            return title.localizedCaseInsensitiveContains(searchText)
+                || repo.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading assigned items...")
+            } else if let error = errorMessage {
+                ErrorView(message: error) { Task { await load() } }
+            } else {
+                List {
+                    if !filteredPRs.isEmpty {
+                        Section("Pull Requests") {
+                            ForEach(filteredPRs) { pr in
+                                PRRow(pr: pr)
+                            }
+                        }
+                    }
+                    if !filteredIssues.isEmpty {
+                        Section("Issues") {
+                            ForEach(filteredIssues) { issue in
+                                IssueRow(issue: issue)
+                            }
+                        }
+                    }
+                    if filteredPRs.isEmpty && filteredIssues.isEmpty {
+                        Text("No items assigned to you")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Assigned")
+        .searchable(text: $searchText, prompt: "Filter items")
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: { Task { await load() } }) {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help("Refresh")
+            }
+        }
+        .task { await load() }
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            async let fetchPRs = client.listPullRequests(username: username, scope: "assigned")
+            async let fetchIssues = client.listIssues(username: username, scope: "assigned")
+            prs = try await fetchPRs
+            issues = try await fetchIssues
+            isLoading = false
+        } catch {
+            errorMessage = "Failed to load assigned items: \(error.localizedDescription)\n\nMake sure the backend is running:\n  go run cmd/gitctl-backend/main.go"
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - Repos View
+
+struct ReposView: View {
     @State private var repos: [GitRepo] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
@@ -10,9 +206,7 @@ struct ContentView: View {
     private let username = "justinsb"
 
     var filteredRepos: [GitRepo] {
-        if searchText.isEmpty {
-            return repos
-        }
+        if searchText.isEmpty { return repos }
         return repos.filter { repo in
             let name = repo.metadata?.name ?? ""
             let desc = repo.spec?.description ?? ""
@@ -22,44 +216,31 @@ struct ContentView: View {
     }
 
     var body: some View {
-        NavigationSplitView {
-            Group {
-                if isLoading {
-                    ProgressView("Loading repositories...")
-                } else if let error = errorMessage {
-                    VStack(spacing: 12) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.largeTitle)
-                            .foregroundStyle(.secondary)
-                        Text(error)
-                            .foregroundStyle(.secondary)
-                        Button("Retry") { Task { await loadRepos() } }
-                    }
-                    .padding()
-                } else {
-                    List(filteredRepos) { repo in
-                        RepoRow(repo: repo)
-                    }
+        Group {
+            if isLoading {
+                ProgressView("Loading repositories...")
+            } else if let error = errorMessage {
+                ErrorView(message: error) { Task { await load() } }
+            } else {
+                List(filteredRepos) { repo in
+                    RepoRow(repo: repo)
                 }
             }
-            .navigationTitle("Repositories")
-            .searchable(text: $searchText, prompt: "Filter repos")
-            .toolbar {
-                ToolbarItem(placement: .automatic) {
-                    Button(action: { Task { await loadRepos() } }) {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                    .help("Refresh")
-                }
-            }
-        } detail: {
-            Text("Select a repository")
-                .foregroundStyle(.secondary)
         }
-        .task { await loadRepos() }
+        .navigationTitle("Repositories")
+        .searchable(text: $searchText, prompt: "Filter repos")
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: { Task { await load() } }) {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help("Refresh")
+            }
+        }
+        .task { await load() }
     }
 
-    func loadRepos() async {
+    func load() async {
         isLoading = true
         errorMessage = nil
         do {
@@ -69,6 +250,106 @@ struct ContentView: View {
             errorMessage = "Failed to load repos: \(error.localizedDescription)\n\nMake sure the backend is running:\n  go run cmd/gitctl-backend/main.go"
             isLoading = false
         }
+    }
+}
+
+// MARK: - Row Views
+
+struct PRRow: View {
+    let pr: PullRequest
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("\(pr.status?.repo ?? "")#\(pr.status?.number ?? 0)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(pr.spec?.title ?? "untitled")
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                if pr.status?.draft == true {
+                    Text("Draft")
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary)
+                        .clipShape(Capsule())
+                }
+                if pr.status?.merged == true {
+                    Text("Merged")
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.purple.opacity(0.2))
+                        .clipShape(Capsule())
+                }
+            }
+
+            HStack(spacing: 12) {
+                Label(pr.status?.author ?? "", systemImage: "person")
+                if let updated = pr.status?.updatedAt, updated.count >= 10 {
+                    Label(String(updated.prefix(10)), systemImage: "clock")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if let labels = pr.status?.labels, !labels.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(labels, id: \.self) { label in
+                        Text(label)
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(.blue.opacity(0.15))
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct IssueRow: View {
+    let issue: Issue
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("\(issue.status?.repo ?? "")#\(issue.status?.number ?? 0)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(issue.spec?.title ?? "untitled")
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+            }
+
+            HStack(spacing: 12) {
+                Label(issue.status?.author ?? "", systemImage: "person")
+                if let updated = issue.status?.updatedAt, updated.count >= 10 {
+                    Label(String(updated.prefix(10)), systemImage: "clock")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if let labels = issue.status?.labels, !labels.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(labels, id: \.self) { label in
+                        Text(label)
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(.blue.opacity(0.15))
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
     }
 }
 
@@ -107,5 +388,24 @@ struct RepoRow: View {
             .foregroundStyle(.secondary)
         }
         .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Shared Components
+
+struct ErrorView: View {
+    let message: String
+    let retry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(message)
+                .foregroundStyle(.secondary)
+            Button("Retry", action: retry)
+        }
+        .padding()
     }
 }

--- a/cmd/gitctl-macos/GitCtlClient.swift
+++ b/cmd/gitctl-macos/GitCtlClient.swift
@@ -22,6 +22,42 @@ class GitCtlClient {
         let repoList = try JSONDecoder().decode(GitRepoList.self, from: data)
         return repoList.items
     }
+
+    func listPullRequests(username: String, scope: String) async throws -> [PullRequest] {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        components.path = "/apis/gitctl.justinsb.com/v1alpha1/pullrequests"
+        components.queryItems = [
+            URLQueryItem(name: "username", value: username),
+            URLQueryItem(name: "scope", value: scope),
+        ]
+
+        let (data, response) = try await URLSession.shared.data(from: components.url!)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw GitCtlError.badResponse
+        }
+
+        let prList = try JSONDecoder().decode(PullRequestList.self, from: data)
+        return prList.items
+    }
+
+    func listIssues(username: String, scope: String) async throws -> [Issue] {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        components.path = "/apis/gitctl.justinsb.com/v1alpha1/issues"
+        components.queryItems = [
+            URLQueryItem(name: "username", value: username),
+            URLQueryItem(name: "scope", value: scope),
+        ]
+
+        let (data, response) = try await URLSession.shared.data(from: components.url!)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw GitCtlError.badResponse
+        }
+
+        let issueList = try JSONDecoder().decode(IssueList.self, from: data)
+        return issueList.items
+    }
 }
 
 enum GitCtlError: LocalizedError {

--- a/cmd/gitctl-macos/Models.swift
+++ b/cmd/gitctl-macos/Models.swift
@@ -43,3 +43,77 @@ struct GitRepoList: Codable {
     var metadata: ListMeta?
     var items: [GitRepo]
 }
+
+// MARK: - PullRequest
+
+struct PullRequestSpec: Codable {
+    var title: String?
+    var body: String?
+}
+
+struct PullRequestStatus: Codable {
+    var repo: String?
+    var number: Int?
+    var state: String?
+    var author: String?
+    var assignees: [String]?
+    var htmlUrl: String?
+    var draft: Bool?
+    var merged: Bool?
+    var labels: [String]?
+    var createdAt: String?
+    var updatedAt: String?
+}
+
+struct PullRequest: Codable, Identifiable {
+    var apiVersion: String?
+    var kind: String?
+    var metadata: ObjectMeta?
+    var spec: PullRequestSpec?
+    var status: PullRequestStatus?
+
+    var id: String { metadata?.name ?? UUID().uuidString }
+}
+
+struct PullRequestList: Codable {
+    var apiVersion: String?
+    var kind: String?
+    var metadata: ListMeta?
+    var items: [PullRequest]
+}
+
+// MARK: - Issue
+
+struct IssueSpec: Codable {
+    var title: String?
+    var body: String?
+}
+
+struct IssueStatus: Codable {
+    var repo: String?
+    var number: Int?
+    var state: String?
+    var author: String?
+    var assignees: [String]?
+    var htmlUrl: String?
+    var labels: [String]?
+    var createdAt: String?
+    var updatedAt: String?
+}
+
+struct Issue: Codable, Identifiable {
+    var apiVersion: String?
+    var kind: String?
+    var metadata: ObjectMeta?
+    var spec: IssueSpec?
+    var status: IssueStatus?
+
+    var id: String { metadata?.name ?? UUID().uuidString }
+}
+
+struct IssueList: Codable {
+    var apiVersion: String?
+    var kind: String?
+    var metadata: ListMeta?
+    var items: [Issue]
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -11,6 +11,14 @@ const (
 	GitRepoKind = "GitRepo"
 	// GitRepoListKind is the Kind name for a list of GitRepo resources.
 	GitRepoListKind = "GitRepoList"
+	// PullRequestKind is the Kind name for a single PullRequest resource.
+	PullRequestKind = "PullRequest"
+	// PullRequestListKind is the Kind name for a list of PullRequest resources.
+	PullRequestListKind = "PullRequestList"
+	// IssueKind is the Kind name for a single Issue resource.
+	IssueKind = "Issue"
+	// IssueListKind is the Kind name for a list of Issue resources.
+	IssueListKind = "IssueList"
 	// APIVersion is the combined apiVersion field value.
 	APIVersion = Group + "/" + Version
 )
@@ -69,8 +77,102 @@ type GitRepo struct {
 
 // GitRepoList is a list of GitRepo resources, following the Kubernetes list convention.
 type GitRepoList struct {
-	APIVersion string     `json:"apiVersion,omitempty"`
-	Kind       string     `json:"kind,omitempty"`
-	Metadata   ListMeta   `json:"metadata,omitempty"`
-	Items      []GitRepo  `json:"items"`
+	APIVersion string    `json:"apiVersion,omitempty"`
+	Kind       string    `json:"kind,omitempty"`
+	Metadata   ListMeta  `json:"metadata,omitempty"`
+	Items      []GitRepo `json:"items"`
+}
+
+// PullRequestSpec contains user-specified fields for a pull request.
+type PullRequestSpec struct {
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+}
+
+// PullRequestStatus contains GitHub-generated (observed) fields for a pull request.
+type PullRequestStatus struct {
+	// Repo is the "owner/repo" qualified name.
+	Repo string `json:"repo,omitempty"`
+	// Number is the PR number within the repository.
+	Number int `json:"number,omitempty"`
+	// State is the PR state (open, closed).
+	State string `json:"state,omitempty"`
+	// Author is the GitHub username who created the PR.
+	Author string `json:"author,omitempty"`
+	// Assignees are the GitHub usernames assigned to the PR.
+	Assignees []string `json:"assignees,omitempty"`
+	// HTMLURL is the browser URL for the pull request.
+	HTMLURL string `json:"htmlUrl,omitempty"`
+	// Draft indicates whether this is a draft PR.
+	Draft bool `json:"draft,omitempty"`
+	// Merged indicates whether the PR has been merged.
+	Merged bool `json:"merged,omitempty"`
+	// Labels are the label names applied to the PR.
+	Labels []string `json:"labels,omitempty"`
+	// CreatedAt is the RFC 3339 timestamp when the PR was created.
+	CreatedAt string `json:"createdAt,omitempty"`
+	// UpdatedAt is the RFC 3339 timestamp of the last update.
+	UpdatedAt string `json:"updatedAt,omitempty"`
+}
+
+// PullRequest represents a GitHub pull request as a Kubernetes-style CRD resource.
+type PullRequest struct {
+	APIVersion string              `json:"apiVersion,omitempty"`
+	Kind       string              `json:"kind,omitempty"`
+	Metadata   ObjectMeta          `json:"metadata,omitempty"`
+	Spec       PullRequestSpec     `json:"spec,omitempty"`
+	Status     PullRequestStatus   `json:"status,omitempty"`
+}
+
+// PullRequestList is a list of PullRequest resources.
+type PullRequestList struct {
+	APIVersion string          `json:"apiVersion,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
+	Metadata   ListMeta        `json:"metadata,omitempty"`
+	Items      []PullRequest   `json:"items"`
+}
+
+// IssueSpec contains user-specified fields for an issue.
+type IssueSpec struct {
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+}
+
+// IssueStatus contains GitHub-generated (observed) fields for an issue.
+type IssueStatus struct {
+	// Repo is the "owner/repo" qualified name.
+	Repo string `json:"repo,omitempty"`
+	// Number is the issue number within the repository.
+	Number int `json:"number,omitempty"`
+	// State is the issue state (open, closed).
+	State string `json:"state,omitempty"`
+	// Author is the GitHub username who created the issue.
+	Author string `json:"author,omitempty"`
+	// Assignees are the GitHub usernames assigned to the issue.
+	Assignees []string `json:"assignees,omitempty"`
+	// HTMLURL is the browser URL for the issue.
+	HTMLURL string `json:"htmlUrl,omitempty"`
+	// Labels are the label names applied to the issue.
+	Labels []string `json:"labels,omitempty"`
+	// CreatedAt is the RFC 3339 timestamp when the issue was created.
+	CreatedAt string `json:"createdAt,omitempty"`
+	// UpdatedAt is the RFC 3339 timestamp of the last update.
+	UpdatedAt string `json:"updatedAt,omitempty"`
+}
+
+// Issue represents a GitHub issue as a Kubernetes-style CRD resource.
+type Issue struct {
+	APIVersion string      `json:"apiVersion,omitempty"`
+	Kind       string      `json:"kind,omitempty"`
+	Metadata   ObjectMeta  `json:"metadata,omitempty"`
+	Spec       IssueSpec   `json:"spec,omitempty"`
+	Status     IssueStatus `json:"status,omitempty"`
+}
+
+// IssueList is a list of Issue resources.
+type IssueList struct {
+	APIVersion string    `json:"apiVersion,omitempty"`
+	Kind       string    `json:"kind,omitempty"`
+	Metadata   ListMeta  `json:"metadata,omitempty"`
+	Items      []Issue   `json:"items"`
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -12,19 +12,25 @@ import (
 
 // Server is the HTTP server exposing the gitctl Kubernetes-style API.
 type Server struct {
-	store storage.GitRepoStore
-	mux   *http.ServeMux
+	repoStore storage.GitRepoStore
+	prStore   storage.PullRequestStore
+	issueStore storage.IssueStore
+	mux       *http.ServeMux
 }
 
 // NewServer creates a new HTTP Server and registers its routes.
-func NewServer(store storage.GitRepoStore) *Server {
+func NewServer(repoStore storage.GitRepoStore, prStore storage.PullRequestStore, issueStore storage.IssueStore) *Server {
 	s := &Server{
-		store: store,
-		mux:   http.NewServeMux(),
+		repoStore:  repoStore,
+		prStore:    prStore,
+		issueStore: issueStore,
+		mux:        http.NewServeMux(),
 	}
 
-	// LIST /apis/gitctl.justinsb.com/v1alpha1/gitrepos
-	s.mux.HandleFunc("/apis/"+api.Group+"/"+api.Version+"/gitrepos", s.handleListGitRepos)
+	base := "/apis/" + api.Group + "/" + api.Version
+	s.mux.HandleFunc(base+"/gitrepos", s.handleListGitRepos)
+	s.mux.HandleFunc(base+"/pullrequests", s.handleListPullRequests)
+	s.mux.HandleFunc(base+"/issues", s.handleListIssues)
 
 	return s
 }
@@ -50,7 +56,7 @@ func (s *Server) handleListGitRepos(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Listing repositories for username: %s", username)
 
-	repos, err := s.store.List(r.Context(), username)
+	repos, err := s.repoStore.List(r.Context(), username)
 	if err != nil {
 		log.Printf("Error listing repositories: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -63,6 +69,94 @@ func (s *Server) handleListGitRepos(w http.ResponseWriter, r *http.Request) {
 		APIVersion: api.APIVersion,
 		Kind:       api.GitRepoListKind,
 		Items:      repos,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(list); err != nil {
+		log.Printf("Error encoding response: %v", err)
+	}
+}
+
+// handleListPullRequests handles GET /apis/gitctl.justinsb.com/v1alpha1/pullrequests.
+// Query parameters: username (required), scope (required: "outbound" or "assigned").
+func (s *Server) handleListPullRequests(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := strings.TrimSpace(r.URL.Query().Get("username"))
+	if username == "" {
+		http.Error(w, "username query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	scope := strings.TrimSpace(r.URL.Query().Get("scope"))
+	if scope == "" {
+		http.Error(w, "scope query parameter is required (outbound or assigned)", http.StatusBadRequest)
+		return
+	}
+
+	key := scope + ":" + username
+	log.Printf("Listing pull requests for key: %s", key)
+
+	prs, err := s.prStore.ListPullRequests(r.Context(), key)
+	if err != nil {
+		log.Printf("Error listing pull requests: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Found %d pull requests for %s", len(prs), key)
+
+	list := api.PullRequestList{
+		APIVersion: api.APIVersion,
+		Kind:       api.PullRequestListKind,
+		Items:      prs,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(list); err != nil {
+		log.Printf("Error encoding response: %v", err)
+	}
+}
+
+// handleListIssues handles GET /apis/gitctl.justinsb.com/v1alpha1/issues.
+// Query parameters: username (required), scope (required: "assigned").
+func (s *Server) handleListIssues(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := strings.TrimSpace(r.URL.Query().Get("username"))
+	if username == "" {
+		http.Error(w, "username query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	scope := strings.TrimSpace(r.URL.Query().Get("scope"))
+	if scope == "" {
+		http.Error(w, "scope query parameter is required (assigned)", http.StatusBadRequest)
+		return
+	}
+
+	key := scope + ":" + username
+	log.Printf("Listing issues for key: %s", key)
+
+	issues, err := s.issueStore.ListIssues(r.Context(), key)
+	if err != nil {
+		log.Printf("Error listing issues: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Found %d issues for %s", len(issues), key)
+
+	list := api.IssueList{
+		APIVersion: api.APIVersion,
+		Kind:       api.IssueListKind,
+		Items:      issues,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/controller/issue.go
+++ b/internal/controller/issue.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/justinsb/gitctl/internal/github"
+	"github.com/justinsb/gitctl/internal/storage"
+)
+
+// IssueController periodically polls GitHub for issues
+// and writes them to storage.
+type IssueController struct {
+	githubClient *github.Client
+	store        storage.IssueStore
+	username     string
+	interval     time.Duration
+}
+
+// NewIssueController creates a new controller that syncs issues for the given username.
+func NewIssueController(client *github.Client, store storage.IssueStore, username string, interval time.Duration) *IssueController {
+	return &IssueController{
+		githubClient: client,
+		store:        store,
+		username:     username,
+		interval:     interval,
+	}
+}
+
+// Run starts the controller loop. It blocks until ctx is cancelled.
+func (c *IssueController) Run(ctx context.Context) {
+	log.Printf("IssueController: starting sync for username %q every %v", c.username, c.interval)
+
+	c.sync(ctx)
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("IssueController: stopping")
+			return
+		case <-ticker.C:
+			c.sync(ctx)
+		}
+	}
+}
+
+func (c *IssueController) sync(ctx context.Context) {
+	log.Printf("IssueController: syncing assigned issues for %s", c.username)
+
+	issues, err := c.githubClient.SearchAssignedIssues(ctx, c.username)
+	if err != nil {
+		log.Printf("IssueController: error fetching assigned issues: %v", err)
+		return
+	}
+
+	if err := c.store.ReplaceAllIssues(ctx, "assigned:"+c.username, issues); err != nil {
+		log.Printf("IssueController: error storing assigned issues: %v", err)
+		return
+	}
+
+	log.Printf("IssueController: synced %d assigned issues for %s", len(issues), c.username)
+}

--- a/internal/controller/pullrequest.go
+++ b/internal/controller/pullrequest.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/justinsb/gitctl/internal/github"
+	"github.com/justinsb/gitctl/internal/storage"
+)
+
+// PullRequestController periodically polls GitHub for pull requests
+// and writes them to storage.
+type PullRequestController struct {
+	githubClient *github.Client
+	store        storage.PullRequestStore
+	username     string
+	interval     time.Duration
+}
+
+// NewPullRequestController creates a new controller that syncs PRs for the given username.
+func NewPullRequestController(client *github.Client, store storage.PullRequestStore, username string, interval time.Duration) *PullRequestController {
+	return &PullRequestController{
+		githubClient: client,
+		store:        store,
+		username:     username,
+		interval:     interval,
+	}
+}
+
+// Run starts the controller loop. It blocks until ctx is cancelled.
+func (c *PullRequestController) Run(ctx context.Context) {
+	log.Printf("PullRequestController: starting sync for username %q every %v", c.username, c.interval)
+
+	c.sync(ctx)
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("PullRequestController: stopping")
+			return
+		case <-ticker.C:
+			c.sync(ctx)
+		}
+	}
+}
+
+func (c *PullRequestController) sync(ctx context.Context) {
+	log.Printf("PullRequestController: syncing PRs for %s", c.username)
+
+	// Sync outbound PRs (authored by user).
+	outbound, err := c.githubClient.SearchPullRequestsByAuthor(ctx, c.username)
+	if err != nil {
+		log.Printf("PullRequestController: error fetching outbound PRs: %v", err)
+	} else {
+		if err := c.store.ReplaceAllPullRequests(ctx, "outbound:"+c.username, outbound); err != nil {
+			log.Printf("PullRequestController: error storing outbound PRs: %v", err)
+		} else {
+			log.Printf("PullRequestController: synced %d outbound PRs for %s", len(outbound), c.username)
+		}
+	}
+
+	// Sync assigned PRs.
+	assigned, err := c.githubClient.SearchAssignedPullRequests(ctx, c.username)
+	if err != nil {
+		log.Printf("PullRequestController: error fetching assigned PRs: %v", err)
+	} else {
+		if err := c.store.ReplaceAllPullRequests(ctx, "assigned:"+c.username, assigned); err != nil {
+			log.Printf("PullRequestController: error storing assigned PRs: %v", err)
+		} else {
+			log.Printf("PullRequestController: synced %d assigned PRs for %s", len(assigned), c.username)
+		}
+	}
+}

--- a/internal/frontend/model.go
+++ b/internal/frontend/model.go
@@ -21,7 +21,21 @@ var (
 	selectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
 	paginationStyle   = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
 	helpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
+	tabStyle          = lipgloss.NewStyle().Padding(0, 2)
+	activeTabStyle    = lipgloss.NewStyle().Padding(0, 2).Bold(true).Foreground(lipgloss.Color("170"))
+	tabBarStyle       = lipgloss.NewStyle().MarginLeft(2).MarginBottom(1)
 )
+
+// Tab represents a screen/tab in the TUI.
+type Tab int
+
+const (
+	TabFeed     Tab = iota // Outbound PRs
+	TabAssigned            // Assigned PRs + Issues
+	TabRepos               // Repositories
+)
+
+var tabNames = []string{"Feed", "Assigned", "Repos"}
 
 // Client is a minimal HTTP client that communicates with the gitctl backend
 // over a Unix domain socket using the Kubernetes wire protocol.
@@ -39,13 +53,11 @@ func NewClient(socketPath string) *Client {
 	}
 	return &Client{
 		httpClient: &http.Client{Transport: transport},
-		// The hostname is a placeholder; the socket dialer ignores it.
-		baseURL: "http://localhost",
+		baseURL:    "http://localhost",
 	}
 }
 
-// ListGitRepos calls GET /apis/gitctl.justinsb.com/v1alpha1/gitrepos and returns
-// the parsed GitRepoList.
+// ListGitRepos calls GET /apis/.../gitrepos.
 func (c *Client) ListGitRepos(ctx context.Context, username string) ([]api.GitRepo, error) {
 	url := fmt.Sprintf("%s/apis/%s/%s/gitrepos?username=%s",
 		c.baseURL, api.Group, api.Version, username)
@@ -75,19 +87,81 @@ func (c *Client) ListGitRepos(ctx context.Context, username string) ([]api.GitRe
 	return repoList.Items, nil
 }
 
-type item struct {
+// ListPullRequests calls GET /apis/.../pullrequests.
+func (c *Client) ListPullRequests(ctx context.Context, username, scope string) ([]api.PullRequest, error) {
+	url := fmt.Sprintf("%s/apis/%s/%s/pullrequests?username=%s&scope=%s",
+		c.baseURL, api.Group, api.Version, username, scope)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to contact backend: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("backend returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var prList api.PullRequestList
+	if err := json.NewDecoder(resp.Body).Decode(&prList); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return prList.Items, nil
+}
+
+// ListIssues calls GET /apis/.../issues.
+func (c *Client) ListIssues(ctx context.Context, username, scope string) ([]api.Issue, error) {
+	url := fmt.Sprintf("%s/apis/%s/%s/issues?username=%s&scope=%s",
+		c.baseURL, api.Group, api.Version, username, scope)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to contact backend: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("backend returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var issueList api.IssueList
+	if err := json.NewDecoder(resp.Body).Decode(&issueList); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return issueList.Items, nil
+}
+
+// --- Repo list item (existing) ---
+
+type repoItem struct {
 	repo api.GitRepo
 }
 
-func (i item) FilterValue() string { return i.repo.Status.FullName }
+func (i repoItem) FilterValue() string { return i.repo.Status.FullName }
 
-type itemDelegate struct{}
+type repoDelegate struct{}
 
-func (d itemDelegate) Height() int                             { return 3 }
-func (d itemDelegate) Spacing() int                            { return 1 }
-func (d itemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
-func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
-	i, ok := listItem.(item)
+func (d repoDelegate) Height() int                             { return 3 }
+func (d repoDelegate) Spacing() int                            { return 1 }
+func (d repoDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+func (d repoDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(repoItem)
 	if !ok {
 		return
 	}
@@ -97,7 +171,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	if repo.Spec.Description != "" {
 		displayText += fmt.Sprintf("\n    %s", repo.Spec.Description)
 	}
-	displayText += fmt.Sprintf("\n    ⭐ %d | 🍴 %d", repo.Status.StargazersCount, repo.Status.ForksCount)
+	displayText += fmt.Sprintf("\n    * %d | fork %d", repo.Status.StargazersCount, repo.Status.ForksCount)
 	if repo.Status.Language != "" {
 		displayText += fmt.Sprintf(" | %s", repo.Status.Language)
 	}
@@ -112,44 +186,236 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	fmt.Fprint(w, fn(displayText))
 }
 
-// Model is the bubbletea model for the repository list TUI.
-type Model struct {
-	client   *Client
-	username string
-	list     list.Model
-	repos    []api.GitRepo
-	loading  bool
-	err      error
+// --- PR list item ---
+
+type prItem struct {
+	pr api.PullRequest
 }
+
+func (i prItem) FilterValue() string {
+	return fmt.Sprintf("%s#%d %s", i.pr.Status.Repo, i.pr.Status.Number, i.pr.Spec.Title)
+}
+
+type prDelegate struct{}
+
+func (d prDelegate) Height() int                             { return 3 }
+func (d prDelegate) Spacing() int                            { return 1 }
+func (d prDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+func (d prDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(prItem)
+	if !ok {
+		return
+	}
+
+	pr := i.pr
+	title := fmt.Sprintf("%s#%d %s", pr.Status.Repo, pr.Status.Number, pr.Spec.Title)
+
+	details := fmt.Sprintf("    %s", pr.Status.Author)
+	if pr.Status.Draft {
+		details += " [draft]"
+	}
+	if pr.Status.Merged {
+		details += " [merged]"
+	}
+	if len(pr.Status.Labels) > 0 {
+		details += " | " + strings.Join(pr.Status.Labels, ", ")
+	}
+
+	updated := ""
+	if pr.Status.UpdatedAt != "" {
+		updated = fmt.Sprintf("\n    updated %s", formatTime(pr.Status.UpdatedAt))
+	}
+
+	displayText := title + "\n" + details + updated
+
+	fn := itemStyle.Render
+	if index == m.Index() {
+		fn = func(s ...string) string {
+			return selectedItemStyle.Render("> " + strings.Join(s, " "))
+		}
+	}
+
+	fmt.Fprint(w, fn(displayText))
+}
+
+// --- Issue list item ---
+
+type issueItem struct {
+	issue api.Issue
+}
+
+func (i issueItem) FilterValue() string {
+	return fmt.Sprintf("%s#%d %s", i.issue.Status.Repo, i.issue.Status.Number, i.issue.Spec.Title)
+}
+
+type issueDelegate struct{}
+
+func (d issueDelegate) Height() int                             { return 3 }
+func (d issueDelegate) Spacing() int                            { return 1 }
+func (d issueDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+func (d issueDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(issueItem)
+	if !ok {
+		return
+	}
+
+	issue := i.issue
+	title := fmt.Sprintf("%s#%d %s", issue.Status.Repo, issue.Status.Number, issue.Spec.Title)
+
+	details := fmt.Sprintf("    %s", issue.Status.Author)
+	if len(issue.Status.Labels) > 0 {
+		details += " | " + strings.Join(issue.Status.Labels, ", ")
+	}
+
+	updated := ""
+	if issue.Status.UpdatedAt != "" {
+		updated = fmt.Sprintf("\n    updated %s", formatTime(issue.Status.UpdatedAt))
+	}
+
+	displayText := title + "\n" + details + updated
+
+	fn := itemStyle.Render
+	if index == m.Index() {
+		fn = func(s ...string) string {
+			return selectedItemStyle.Render("> " + strings.Join(s, " "))
+		}
+	}
+
+	fmt.Fprint(w, fn(displayText))
+}
+
+// formatTime truncates an RFC 3339 timestamp to just the date for display.
+func formatTime(t string) string {
+	if len(t) >= 10 {
+		return t[:10]
+	}
+	return t
+}
+
+// --- Messages ---
 
 type reposLoadedMsg struct {
 	repos []api.GitRepo
+}
+
+type feedLoadedMsg struct {
+	prs []api.PullRequest
+}
+
+type assignedPRsLoadedMsg struct {
+	prs []api.PullRequest
+}
+
+type assignedIssuesLoadedMsg struct {
+	issues []api.Issue
 }
 
 type errMsg struct {
 	err error
 }
 
+// --- Model ---
+
+// Model is the bubbletea model for the TUI with tabbed navigation.
+type Model struct {
+	client   *Client
+	username string
+
+	activeTab Tab
+	width     int
+	height    int
+
+	// Feed tab (outbound PRs)
+	feedList    list.Model
+	feedLoading bool
+
+	// Assigned tab (PRs + Issues combined)
+	assignedList    list.Model
+	assignedLoading bool
+
+	// Repos tab
+	repoList    list.Model
+	repoLoading bool
+
+	err error
+}
+
 // NewModel creates a new TUI Model using the given backend client and GitHub username.
 func NewModel(client *Client, username string) Model {
-	l := list.New([]list.Item{}, itemDelegate{}, 0, 0)
-	l.Title = fmt.Sprintf("Repositories for %s", username)
-	l.SetShowStatusBar(true)
-	l.SetFilteringEnabled(true)
-	l.Styles.Title = titleStyle
-	l.Styles.PaginationStyle = paginationStyle
-	l.Styles.HelpStyle = helpStyle
+	feedList := list.New([]list.Item{}, prDelegate{}, 0, 0)
+	feedList.Title = "Feed - My Pull Requests"
+	feedList.SetShowStatusBar(true)
+	feedList.SetFilteringEnabled(true)
+	feedList.Styles.Title = titleStyle
+	feedList.Styles.PaginationStyle = paginationStyle
+	feedList.Styles.HelpStyle = helpStyle
+
+	assignedList := list.New([]list.Item{}, prDelegate{}, 0, 0)
+	assignedList.Title = "Assigned to Me"
+	assignedList.SetShowStatusBar(true)
+	assignedList.SetFilteringEnabled(true)
+	assignedList.Styles.Title = titleStyle
+	assignedList.Styles.PaginationStyle = paginationStyle
+	assignedList.Styles.HelpStyle = helpStyle
+
+	repoList := list.New([]list.Item{}, repoDelegate{}, 0, 0)
+	repoList.Title = fmt.Sprintf("Repositories for %s", username)
+	repoList.SetShowStatusBar(true)
+	repoList.SetFilteringEnabled(true)
+	repoList.Styles.Title = titleStyle
+	repoList.Styles.PaginationStyle = paginationStyle
+	repoList.Styles.HelpStyle = helpStyle
 
 	return Model{
-		client:   client,
-		username: username,
-		list:     l,
-		loading:  true,
+		client:          client,
+		username:        username,
+		activeTab:       TabFeed,
+		feedList:        feedList,
+		feedLoading:     true,
+		assignedList:    assignedList,
+		assignedLoading: true,
+		repoList:        repoList,
+		repoLoading:     true,
 	}
 }
 
 func (m Model) Init() tea.Cmd {
-	return loadRepos(m.client, m.username)
+	return tea.Batch(
+		loadFeed(m.client, m.username),
+		loadAssignedPRs(m.client, m.username),
+		loadAssignedIssues(m.client, m.username),
+		loadRepos(m.client, m.username),
+	)
+}
+
+func loadFeed(client *Client, username string) tea.Cmd {
+	return func() tea.Msg {
+		prs, err := client.ListPullRequests(context.Background(), username, "outbound")
+		if err != nil {
+			return errMsg{err}
+		}
+		return feedLoadedMsg{prs: prs}
+	}
+}
+
+func loadAssignedPRs(client *Client, username string) tea.Cmd {
+	return func() tea.Msg {
+		prs, err := client.ListPullRequests(context.Background(), username, "assigned")
+		if err != nil {
+			return errMsg{err}
+		}
+		return assignedPRsLoadedMsg{prs: prs}
+	}
+}
+
+func loadAssignedIssues(client *Client, username string) tea.Cmd {
+	return func() tea.Msg {
+		issues, err := client.ListIssues(context.Background(), username, "assigned")
+		if err != nil {
+			return errMsg{err}
+		}
+		return assignedIssuesLoadedMsg{issues: issues}
+	}
 }
 
 func loadRepos(client *Client, username string) tea.Cmd {
@@ -165,43 +431,136 @@ func loadRepos(client *Client, username string) tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.list.SetWidth(msg.Width)
-		m.list.SetHeight(msg.Height - 2)
+		m.width = msg.Width
+		m.height = msg.Height
+		listHeight := msg.Height - 4 // account for tab bar
+		m.feedList.SetWidth(msg.Width)
+		m.feedList.SetHeight(listHeight)
+		m.assignedList.SetWidth(msg.Width)
+		m.assignedList.SetHeight(listHeight)
+		m.repoList.SetWidth(msg.Width)
+		m.repoList.SetHeight(listHeight)
+		return m, nil
+
+	case feedLoadedMsg:
+		m.feedLoading = false
+		items := make([]list.Item, len(msg.prs))
+		for i, pr := range msg.prs {
+			items[i] = prItem{pr: pr}
+		}
+		m.feedList.SetItems(items)
+		return m, nil
+
+	case assignedPRsLoadedMsg:
+		m.assignedLoading = false
+		// Combine assigned PRs with any existing assigned issues
+		existing := m.assignedList.Items()
+		items := make([]list.Item, 0, len(msg.prs)+len(existing))
+		for _, pr := range msg.prs {
+			items = append(items, prItem{pr: pr})
+		}
+		// Keep existing issue items
+		for _, item := range existing {
+			if _, ok := item.(issueItem); ok {
+				items = append(items, item)
+			}
+		}
+		m.assignedList.SetItems(items)
+		return m, nil
+
+	case assignedIssuesLoadedMsg:
+		// Combine assigned issues with any existing assigned PRs
+		existing := m.assignedList.Items()
+		items := make([]list.Item, 0, len(msg.issues)+len(existing))
+		// Keep existing PR items
+		for _, item := range existing {
+			if _, ok := item.(prItem); ok {
+				items = append(items, item)
+			}
+		}
+		for _, issue := range msg.issues {
+			items = append(items, issueItem{issue: issue})
+		}
+		m.assignedList.SetItems(items)
 		return m, nil
 
 	case reposLoadedMsg:
-		m.loading = false
-		m.repos = msg.repos
+		m.repoLoading = false
 		items := make([]list.Item, len(msg.repos))
 		for i, repo := range msg.repos {
-			items[i] = item{repo: repo}
+			items[i] = repoItem{repo: repo}
 		}
-		m.list.SetItems(items)
+		m.repoList.SetItems(items)
 		return m, nil
 
 	case errMsg:
-		m.loading = false
 		m.err = msg.err
-		return m, tea.Quit
+		return m, nil
 
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
+		case "ctrl+]", "tab":
+			m.activeTab = (m.activeTab + 1) % Tab(len(tabNames))
+			return m, nil
+		case "shift+tab":
+			m.activeTab = (m.activeTab - 1 + Tab(len(tabNames))) % Tab(len(tabNames))
+			return m, nil
 		}
 	}
 
+	// Update the active list
 	var cmd tea.Cmd
-	m.list, cmd = m.list.Update(msg)
+	switch m.activeTab {
+	case TabFeed:
+		m.feedList, cmd = m.feedList.Update(msg)
+	case TabAssigned:
+		m.assignedList, cmd = m.assignedList.Update(msg)
+	case TabRepos:
+		m.repoList, cmd = m.repoList.Update(msg)
+	}
 	return m, cmd
 }
 
 func (m Model) View() string {
-	if m.loading {
-		return "\n  Loading repositories...\n"
-	}
 	if m.err != nil {
 		return fmt.Sprintf("\n  Error: %v\n", m.err)
 	}
-	return "\n" + m.list.View()
+
+	// Render tab bar
+	var tabs []string
+	for i, name := range tabNames {
+		if Tab(i) == m.activeTab {
+			tabs = append(tabs, activeTabStyle.Render("["+name+"]"))
+		} else {
+			tabs = append(tabs, tabStyle.Render(" "+name+" "))
+		}
+	}
+	tabBar := tabBarStyle.Render(strings.Join(tabs, " "))
+
+	// Render active tab content
+	var content string
+	switch m.activeTab {
+	case TabFeed:
+		if m.feedLoading {
+			content = "\n  Loading feed...\n"
+		} else {
+			content = m.feedList.View()
+		}
+	case TabAssigned:
+		if m.assignedLoading {
+			content = "\n  Loading assigned items...\n"
+		} else {
+			content = m.assignedList.View()
+		}
+	case TabRepos:
+		if m.repoLoading {
+			content = "\n  Loading repositories...\n"
+		} else {
+			content = m.repoList.View()
+		}
+	}
+
+	return "\n" + tabBar + "\n" + content
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"os"
 	"time"
 
 	"github.com/justinsb/gitctl/internal/api"
@@ -14,15 +16,25 @@ import (
 type Client struct {
 	httpClient *http.Client
 	baseURL    string
+	token      string
 }
 
-// NewClient creates a new GitHub API client
+// NewClient creates a new GitHub API client.
+// If GITHUB_TOKEN is set in the environment, it will be used for authentication.
 func NewClient() *Client {
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 		baseURL: "https://api.github.com",
+		token:   os.Getenv("GITHUB_TOKEN"),
+	}
+}
+
+// setAuthHeader adds the Authorization header if a token is configured.
+func (c *Client) setAuthHeader(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 }
 
@@ -54,6 +66,7 @@ func (c *Client) ListRepositories(ctx context.Context, username string) ([]api.G
 	}
 
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	c.setAuthHeader(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -100,4 +113,180 @@ func (c *Client) ListRepositories(ctx context.Context, username string) ([]api.G
 	}
 
 	return repos, nil
+}
+
+// githubSearchResult represents the response from the GitHub Search API.
+type githubSearchResult struct {
+	Items []githubSearchItem `json:"items"`
+}
+
+// githubSearchItem represents an item from the GitHub Search API (/search/issues).
+type githubSearchItem struct {
+	Number      int              `json:"number"`
+	Title       string           `json:"title"`
+	Body        string           `json:"body"`
+	State       string           `json:"state"`
+	HTMLURL     string           `json:"html_url"`
+	CreatedAt   string           `json:"created_at"`
+	UpdatedAt   string           `json:"updated_at"`
+	Draft       bool             `json:"draft"`
+	User        githubUser       `json:"user"`
+	Assignees   []githubUser     `json:"assignees"`
+	Labels      []githubLabel    `json:"labels"`
+	PullRequest *githubPRRef     `json:"pull_request"`
+	Repository  githubRepository `json:"repository"`
+}
+
+type githubUser struct {
+	Login string `json:"login"`
+}
+
+type githubLabel struct {
+	Name string `json:"name"`
+}
+
+type githubPRRef struct {
+	MergedAt string `json:"merged_at"`
+}
+
+type githubRepository struct {
+	FullName string `json:"full_name"`
+}
+
+// searchIssues performs a GitHub search and returns the raw items.
+func (c *Client) searchIssues(ctx context.Context, query string) ([]githubSearchItem, error) {
+	u := fmt.Sprintf("%s/search/issues?q=%s&sort=updated&order=desc&per_page=100",
+		c.baseURL, url.QueryEscape(query))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	c.setAuthHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search issues: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub Search API returned status %d", resp.StatusCode)
+	}
+
+	var result githubSearchResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode search response: %w", err)
+	}
+
+	return result.Items, nil
+}
+
+// SearchPullRequestsByAuthor returns open PRs authored by the given username.
+func (c *Client) SearchPullRequestsByAuthor(ctx context.Context, username string) ([]api.PullRequest, error) {
+	query := fmt.Sprintf("type:pr author:%s is:open", username)
+	items, err := c.searchIssues(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return convertToPullRequests(items), nil
+}
+
+// SearchAssignedPullRequests returns open PRs assigned to the given username.
+func (c *Client) SearchAssignedPullRequests(ctx context.Context, username string) ([]api.PullRequest, error) {
+	query := fmt.Sprintf("type:pr assignee:%s is:open", username)
+	items, err := c.searchIssues(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return convertToPullRequests(items), nil
+}
+
+// SearchAssignedIssues returns open issues assigned to the given username.
+func (c *Client) SearchAssignedIssues(ctx context.Context, username string) ([]api.Issue, error) {
+	query := fmt.Sprintf("type:issue assignee:%s is:open", username)
+	items, err := c.searchIssues(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return convertToIssues(items), nil
+}
+
+func convertToPullRequests(items []githubSearchItem) []api.PullRequest {
+	prs := make([]api.PullRequest, len(items))
+	for i, item := range items {
+		assignees := make([]string, len(item.Assignees))
+		for j, a := range item.Assignees {
+			assignees[j] = a.Login
+		}
+		labels := make([]string, len(item.Labels))
+		for j, l := range item.Labels {
+			labels[j] = l.Name
+		}
+		merged := item.PullRequest != nil && item.PullRequest.MergedAt != ""
+		prs[i] = api.PullRequest{
+			APIVersion: api.APIVersion,
+			Kind:       api.PullRequestKind,
+			Metadata: api.ObjectMeta{
+				Name: fmt.Sprintf("%s#%d", item.Repository.FullName, item.Number),
+			},
+			Spec: api.PullRequestSpec{
+				Title: item.Title,
+				Body:  item.Body,
+			},
+			Status: api.PullRequestStatus{
+				Repo:      item.Repository.FullName,
+				Number:    item.Number,
+				State:     item.State,
+				Author:    item.User.Login,
+				Assignees: assignees,
+				HTMLURL:   item.HTMLURL,
+				Draft:     item.Draft,
+				Merged:    merged,
+				Labels:    labels,
+				CreatedAt: item.CreatedAt,
+				UpdatedAt: item.UpdatedAt,
+			},
+		}
+	}
+	return prs
+}
+
+func convertToIssues(items []githubSearchItem) []api.Issue {
+	issues := make([]api.Issue, len(items))
+	for i, item := range items {
+		assignees := make([]string, len(item.Assignees))
+		for j, a := range item.Assignees {
+			assignees[j] = a.Login
+		}
+		labels := make([]string, len(item.Labels))
+		for j, l := range item.Labels {
+			labels[j] = l.Name
+		}
+		issues[i] = api.Issue{
+			APIVersion: api.APIVersion,
+			Kind:       api.IssueKind,
+			Metadata: api.ObjectMeta{
+				Name: fmt.Sprintf("%s#%d", item.Repository.FullName, item.Number),
+			},
+			Spec: api.IssueSpec{
+				Title: item.Title,
+				Body:  item.Body,
+			},
+			Status: api.IssueStatus{
+				Repo:      item.Repository.FullName,
+				Number:    item.Number,
+				State:     item.State,
+				Author:    item.User.Login,
+				Assignees: assignees,
+				HTMLURL:   item.HTMLURL,
+				Labels:    labels,
+				CreatedAt: item.CreatedAt,
+				UpdatedAt: item.UpdatedAt,
+			},
+		}
+	}
+	return issues
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -18,3 +18,23 @@ type GitRepoStore interface {
 	// This is used by controllers to sync the full state from an external source.
 	ReplaceAll(ctx context.Context, username string, repos []api.GitRepo) error
 }
+
+// PullRequestStore provides read and write access to PullRequest resources.
+// The key parameter is a scoped identifier like "outbound:username" or "assigned:username".
+type PullRequestStore interface {
+	// ListPullRequests returns all PullRequest resources for the given key.
+	ListPullRequests(ctx context.Context, key string) ([]api.PullRequest, error)
+
+	// ReplaceAllPullRequests atomically replaces all PullRequest resources for a key.
+	ReplaceAllPullRequests(ctx context.Context, key string, prs []api.PullRequest) error
+}
+
+// IssueStore provides read and write access to Issue resources.
+// The key parameter is a scoped identifier like "assigned:username".
+type IssueStore interface {
+	// ListIssues returns all Issue resources for the given key.
+	ListIssues(ctx context.Context, key string) ([]api.Issue, error)
+
+	// ReplaceAllIssues atomically replaces all Issue resources for a key.
+	ReplaceAllIssues(ctx context.Context, key string, issues []api.Issue) error
+}

--- a/internal/storage/memorystorage/memorystorage.go
+++ b/internal/storage/memorystorage/memorystorage.go
@@ -9,19 +9,25 @@ import (
 	"github.com/justinsb/gitctl/internal/storage"
 )
 
-// ensure MemoryStore implements GitRepoStore.
+// ensure MemoryStore implements all store interfaces.
 var _ storage.GitRepoStore = &MemoryStore{}
+var _ storage.PullRequestStore = &MemoryStore{}
+var _ storage.IssueStore = &MemoryStore{}
 
-// MemoryStore is a thread-safe in-memory store for GitRepo resources.
+// MemoryStore is a thread-safe in-memory store for all resource types.
 type MemoryStore struct {
 	mu    sync.RWMutex
-	repos map[string][]api.GitRepo // keyed by username
+	repos map[string][]api.GitRepo      // keyed by username
+	prs   map[string][]api.PullRequest  // keyed by scope (e.g. "outbound:user")
+	issues map[string][]api.Issue        // keyed by scope (e.g. "assigned:user")
 }
 
 // New creates a new MemoryStore.
 func New() *MemoryStore {
 	return &MemoryStore{
-		repos: make(map[string][]api.GitRepo),
+		repos:  make(map[string][]api.GitRepo),
+		prs:    make(map[string][]api.PullRequest),
+		issues: make(map[string][]api.Issue),
 	}
 }
 
@@ -35,7 +41,6 @@ func (s *MemoryStore) List(ctx context.Context, username string) ([]api.GitRepo,
 		return nil, nil
 	}
 
-	// Return a copy to avoid data races.
 	out := make([]api.GitRepo, len(repos))
 	copy(out, repos)
 	return out, nil
@@ -46,9 +51,60 @@ func (s *MemoryStore) ReplaceAll(ctx context.Context, username string, repos []a
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Store a copy.
 	stored := make([]api.GitRepo, len(repos))
 	copy(stored, repos)
 	s.repos[username] = stored
+	return nil
+}
+
+// ListPullRequests returns all PullRequest resources for the given key.
+func (s *MemoryStore) ListPullRequests(ctx context.Context, key string) ([]api.PullRequest, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	prs := s.prs[key]
+	if prs == nil {
+		return nil, nil
+	}
+
+	out := make([]api.PullRequest, len(prs))
+	copy(out, prs)
+	return out, nil
+}
+
+// ReplaceAllPullRequests atomically replaces all PullRequest resources for a key.
+func (s *MemoryStore) ReplaceAllPullRequests(ctx context.Context, key string, prs []api.PullRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stored := make([]api.PullRequest, len(prs))
+	copy(stored, prs)
+	s.prs[key] = stored
+	return nil
+}
+
+// ListIssues returns all Issue resources for the given key.
+func (s *MemoryStore) ListIssues(ctx context.Context, key string) ([]api.Issue, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	issues := s.issues[key]
+	if issues == nil {
+		return nil, nil
+	}
+
+	out := make([]api.Issue, len(issues))
+	copy(out, issues)
+	return out, nil
+}
+
+// ReplaceAllIssues atomically replaces all Issue resources for a key.
+func (s *MemoryStore) ReplaceAllIssues(ctx context.Context, key string, issues []api.Issue) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stored := make([]api.Issue, len(issues))
+	copy(stored, issues)
+	s.issues[key] = stored
 	return nil
 }


### PR DESCRIPTION
## Summary
- Adds two new screens to both TUI and macOS SwiftUI frontends: **Feed** (outbound PRs) and **Assigned** (PRs + Issues assigned to user), sorted by last updated
- Introduces `PullRequest` and `Issue` CRD types, storage interfaces, and periodic sync controllers using the GitHub Search API
- Adds `GITHUB_TOKEN` env var support for authenticated requests (higher rate limits, private repo access)
- TUI navigation via Tab/Shift+Tab; macOS uses sidebar with NavigationSplitView

## Test plan
- [ ] Set `GITHUB_TOKEN` env var and run `go run cmd/gitctl-backend/main.go` — verify it logs syncing PRs and issues
- [ ] Run `go run cmd/gitctl/main.go` — verify Feed tab shows outbound PRs, Tab/Shift+Tab switches screens
- [ ] Build and run macOS app — verify sidebar navigation between Feed, Assigned, Repositories
- [ ] Verify `go build ./...` and `go vet ./...` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)