### PR TITLE
Improve presentation of PR review comments

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -302,6 +302,7 @@ type ReviewCommentStatus struct {
 	UpdatedAt string `json:"updatedAt,omitempty"`
 	DiffHunk  string `json:"diffHunk,omitempty"`
 	InReplyTo int    `json:"inReplyTo,omitempty"`
+	Outdated  bool   `json:"outdated,omitempty"`
 }
 
 // ReviewComment represents a file-level review comment on a pull request.

--- a/internal/backend/render_test.go
+++ b/internal/backend/render_test.go
@@ -106,13 +106,16 @@ func runPRGoldenTest(t *testing.T, dir string) {
 			buildData: func() prDetailData {
 				c := cloneComments(comments)
 				renderCommentBodies(c)
+				rc := cloneReviewComments(reviewComments)
+				renderReviewCommentBodies(rc)
 				return prDetailData{
-					Owner:     owner,
-					Repo:      repo,
-					Number:    number,
-					ActiveTab: "conversation",
-					PR:        &pr,
-					Comments:  c,
+					Owner:          owner,
+					Repo:           repo,
+					Number:         number,
+					ActiveTab:      "conversation",
+					PR:             &pr,
+					Comments:       c,
+					ReviewComments: rc,
 				}
 			},
 		},

--- a/internal/backend/templates.go
+++ b/internal/backend/templates.go
@@ -169,6 +169,39 @@ const prDetailTemplateStr = `<!DOCTYPE html>
   <p class="meta">No comments yet.</p>
   {{end}}
 
+  {{if .ReviewComments}}
+  <h2>Review comments</h2>
+  {{range .ReviewComments}}
+  {{if .Status.Outdated}}
+  <details class="outdated-comment">
+    <summary class="outdated-summary">
+      <span class="outdated-badge">Outdated</span>
+      <span class="comment-author">{{.Status.Author}}</span> commented on <code>{{.Status.Path}}</code>
+      <span class="comment-date">{{shortDate .Status.CreatedAt}}</span>
+    </summary>
+    <div class="comment">
+      <div class="comment-header">
+        <span class="comment-author">{{.Status.Author}}</span>
+        <span class="comment-date">{{shortDate .Status.CreatedAt}}</span>
+      </div>
+      <div class="markdown-body">{{safeHTML .Spec.Body}}</div>
+    </div>
+  </details>
+  {{else}}
+  <div class="review-comment-conversation">
+    <div class="review-comment-file"><code>{{.Status.Path}}</code>{{if .Status.Line}} line {{.Status.Line}}{{end}}</div>
+    <div class="comment">
+      <div class="comment-header">
+        <span class="comment-author">{{.Status.Author}}</span>
+        <span class="comment-date">{{shortDate .Status.CreatedAt}}</span>
+      </div>
+      <div class="markdown-body">{{safeHTML .Spec.Body}}</div>
+    </div>
+  </div>
+  {{end}}
+  {{end}}
+  {{end}}
+
   <div class="comment-form">
     <h3>Add a comment</h3>
     <form method="POST" action="/ui/repos/{{.Owner}}/{{.Repo}}/pulls/{{.Number}}/comments">
@@ -379,6 +412,9 @@ body {
     .diff-remove .diff-line-content { background: rgba(248,81,73,0.1); }
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
+    .review-comment-file { color: #9198a1; }
+    .outdated-summary { color: #9198a1; border-color: #30363d; }
+    .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
@@ -536,6 +572,26 @@ a:hover { text-decoration: underline; }
 }
 .diff-comment .comment-header { padding: 6px 10px; font-size: 12px; }
 .diff-comment .markdown-body { padding: 8px 10px; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; }
+
+/* Review comments in conversation view */
+.review-comment-conversation { margin-bottom: 12px; }
+.review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
+.review-comment-file code { font-size: 12px; }
+.outdated-comment { margin-bottom: 12px; }
+.outdated-summary {
+    cursor: pointer; padding: 8px 12px; font-size: 13px;
+    color: #656d76; display: flex; gap: 8px; align-items: center;
+    border: 1px solid #d1d9e0; border-radius: 6px;
+    list-style: none;
+}
+.outdated-summary::-webkit-details-marker { display: none; }
+.outdated-summary::before { content: "\25B6"; font-size: 10px; }
+details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
+.outdated-badge {
+    font-size: 11px; padding: 1px 7px; border-radius: 12px;
+    background: rgba(175,184,193,0.2); color: #656d76;
+}
+.outdated-comment .comment { margin-top: 8px; }
 
 /* Markdown body styles */
 .markdown-body { word-wrap: break-word; overflow-wrap: break-word; }

--- a/internal/backend/testdata/simple-issue/_issue_detail.html
+++ b/internal/backend/testdata/simple-issue/_issue_detail.html
@@ -46,6 +46,9 @@ body {
     .diff-remove .diff-line-content { background: rgba(248,81,73,0.1); }
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
+    .review-comment-file { color: #9198a1; }
+    .outdated-summary { color: #9198a1; border-color: #30363d; }
+    .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
@@ -203,6 +206,26 @@ a:hover { text-decoration: underline; }
 }
 .diff-comment .comment-header { padding: 6px 10px; font-size: 12px; }
 .diff-comment .markdown-body { padding: 8px 10px; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; }
+
+ 
+.review-comment-conversation { margin-bottom: 12px; }
+.review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
+.review-comment-file code { font-size: 12px; }
+.outdated-comment { margin-bottom: 12px; }
+.outdated-summary {
+    cursor: pointer; padding: 8px 12px; font-size: 13px;
+    color: #656d76; display: flex; gap: 8px; align-items: center;
+    border: 1px solid #d1d9e0; border-radius: 6px;
+    list-style: none;
+}
+.outdated-summary::-webkit-details-marker { display: none; }
+.outdated-summary::before { content: "\25B6"; font-size: 10px; }
+details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
+.outdated-badge {
+    font-size: 11px; padding: 1px 7px; border-radius: 12px;
+    background: rgba(175,184,193,0.2); color: #656d76;
+}
+.outdated-comment .comment { margin-top: 8px; }
 
  
 .markdown-body { word-wrap: break-word; overflow-wrap: break-word; }

--- a/internal/backend/testdata/simple-pr/_pr_detail_checks.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_checks.html
@@ -46,6 +46,9 @@ body {
     .diff-remove .diff-line-content { background: rgba(248,81,73,0.1); }
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
+    .review-comment-file { color: #9198a1; }
+    .outdated-summary { color: #9198a1; border-color: #30363d; }
+    .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
@@ -203,6 +206,26 @@ a:hover { text-decoration: underline; }
 }
 .diff-comment .comment-header { padding: 6px 10px; font-size: 12px; }
 .diff-comment .markdown-body { padding: 8px 10px; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; }
+
+ 
+.review-comment-conversation { margin-bottom: 12px; }
+.review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
+.review-comment-file code { font-size: 12px; }
+.outdated-comment { margin-bottom: 12px; }
+.outdated-summary {
+    cursor: pointer; padding: 8px 12px; font-size: 13px;
+    color: #656d76; display: flex; gap: 8px; align-items: center;
+    border: 1px solid #d1d9e0; border-radius: 6px;
+    list-style: none;
+}
+.outdated-summary::-webkit-details-marker { display: none; }
+.outdated-summary::before { content: "\25B6"; font-size: 10px; }
+details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
+.outdated-badge {
+    font-size: 11px; padding: 1px 7px; border-radius: 12px;
+    background: rgba(175,184,193,0.2); color: #656d76;
+}
+.outdated-comment .comment { margin-top: 8px; }
 
  
 .markdown-body { word-wrap: break-word; overflow-wrap: break-word; }

--- a/internal/backend/testdata/simple-pr/_pr_detail_commits.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_commits.html
@@ -46,6 +46,9 @@ body {
     .diff-remove .diff-line-content { background: rgba(248,81,73,0.1); }
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
+    .review-comment-file { color: #9198a1; }
+    .outdated-summary { color: #9198a1; border-color: #30363d; }
+    .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
@@ -203,6 +206,26 @@ a:hover { text-decoration: underline; }
 }
 .diff-comment .comment-header { padding: 6px 10px; font-size: 12px; }
 .diff-comment .markdown-body { padding: 8px 10px; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; }
+
+ 
+.review-comment-conversation { margin-bottom: 12px; }
+.review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
+.review-comment-file code { font-size: 12px; }
+.outdated-comment { margin-bottom: 12px; }
+.outdated-summary {
+    cursor: pointer; padding: 8px 12px; font-size: 13px;
+    color: #656d76; display: flex; gap: 8px; align-items: center;
+    border: 1px solid #d1d9e0; border-radius: 6px;
+    list-style: none;
+}
+.outdated-summary::-webkit-details-marker { display: none; }
+.outdated-summary::before { content: "\25B6"; font-size: 10px; }
+details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
+.outdated-badge {
+    font-size: 11px; padding: 1px 7px; border-radius: 12px;
+    background: rgba(175,184,193,0.2); color: #656d76;
+}
+.outdated-comment .comment { margin-top: 8px; }
 
  
 .markdown-body { word-wrap: break-word; overflow-wrap: break-word; }

--- a/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
@@ -46,6 +46,9 @@ body {
     .diff-remove .diff-line-content { background: rgba(248,81,73,0.1); }
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
+    .review-comment-file { color: #9198a1; }
+    .outdated-summary { color: #9198a1; border-color: #30363d; }
+    .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
@@ -205,6 +208,26 @@ a:hover { text-decoration: underline; }
 .diff-comment .markdown-body { padding: 8px 10px; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; }
 
  
+.review-comment-conversation { margin-bottom: 12px; }
+.review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
+.review-comment-file code { font-size: 12px; }
+.outdated-comment { margin-bottom: 12px; }
+.outdated-summary {
+    cursor: pointer; padding: 8px 12px; font-size: 13px;
+    color: #656d76; display: flex; gap: 8px; align-items: center;
+    border: 1px solid #d1d9e0; border-radius: 6px;
+    list-style: none;
+}
+.outdated-summary::-webkit-details-marker { display: none; }
+.outdated-summary::before { content: "\25B6"; font-size: 10px; }
+details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
+.outdated-badge {
+    font-size: 11px; padding: 1px 7px; border-radius: 12px;
+    background: rgba(175,184,193,0.2); color: #656d76;
+}
+.outdated-comment .comment { margin-top: 8px; }
+
+ 
 .markdown-body { word-wrap: break-word; overflow-wrap: break-word; }
 .markdown-body > *:first-child { margin-top: 0; }
 .markdown-body > *:last-child { margin-bottom: 0; }
@@ -295,6 +318,43 @@ a:hover { text-decoration: underline; }
     <div class="markdown-body"><p>Good point, I'll add that in the next commit.</p>
 </div>
   </div>
+  
+  
+
+  
+  <h2>Review comments</h2>
+  
+  
+  <div class="review-comment-conversation">
+    <div class="review-comment-file"><code>auth/login.go</code> line 14</div>
+    <div class="comment">
+      <div class="comment-header">
+        <span class="comment-author">bob</span>
+        <span class="comment-date">2026-03-16</span>
+      </div>
+      <div class="markdown-body"><p>Should we add rate limiting here before calling <code>validateCredentials</code>?</p>
+</div>
+    </div>
+  </div>
+  
+  
+  
+  <details class="outdated-comment">
+    <summary class="outdated-summary">
+      <span class="outdated-badge">Outdated</span>
+      <span class="comment-author">carol</span> commented on <code>auth/login.go</code>
+      <span class="comment-date">2026-03-15</span>
+    </summary>
+    <div class="comment">
+      <div class="comment-header">
+        <span class="comment-author">carol</span>
+        <span class="comment-date">2026-03-15</span>
+      </div>
+      <div class="markdown-body"><p>This error message should be more descriptive.</p>
+</div>
+    </div>
+  </details>
+  
   
   
 

--- a/internal/backend/testdata/simple-pr/_pr_detail_files.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_files.html
@@ -46,6 +46,9 @@ body {
     .diff-remove .diff-line-content { background: rgba(248,81,73,0.1); }
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
+    .review-comment-file { color: #9198a1; }
+    .outdated-summary { color: #9198a1; border-color: #30363d; }
+    .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
@@ -203,6 +206,26 @@ a:hover { text-decoration: underline; }
 }
 .diff-comment .comment-header { padding: 6px 10px; font-size: 12px; }
 .diff-comment .markdown-body { padding: 8px 10px; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; }
+
+ 
+.review-comment-conversation { margin-bottom: 12px; }
+.review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
+.review-comment-file code { font-size: 12px; }
+.outdated-comment { margin-bottom: 12px; }
+.outdated-summary {
+    cursor: pointer; padding: 8px 12px; font-size: 13px;
+    color: #656d76; display: flex; gap: 8px; align-items: center;
+    border: 1px solid #d1d9e0; border-radius: 6px;
+    list-style: none;
+}
+.outdated-summary::-webkit-details-marker { display: none; }
+.outdated-summary::before { content: "\25B6"; font-size: 10px; }
+details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
+.outdated-badge {
+    font-size: 11px; padding: 1px 7px; border-radius: 12px;
+    background: rgba(175,184,193,0.2); color: #656d76;
+}
+.outdated-comment .comment { margin-top: 8px; }
 
  
 .markdown-body { word-wrap: break-word; overflow-wrap: break-word; }

--- a/internal/backend/testdata/simple-pr/reviewcomments.yaml
+++ b/internal/backend/testdata/simple-pr/reviewcomments.yaml
@@ -15,3 +15,21 @@
     diffHunk: |
       @@ -0,0 +1,25 @@
       +package auth
+- apiVersion: gitctl.justinsb.com/v1alpha1
+  kind: ReviewComment
+  metadata:
+    name: "testorg/testrepo#42-review-202"
+  spec:
+    body: "This error message should be more descriptive."
+  status:
+    path: "auth/login.go"
+    line: 10
+    side: "RIGHT"
+    author: "carol"
+    htmlUrl: "https://github.com/testorg/testrepo/pull/42#discussion_r202"
+    createdAt: "2026-03-15T14:30:00Z"
+    updatedAt: "2026-03-15T14:30:00Z"
+    outdated: true
+    diffHunk: |
+      @@ -0,0 +1,25 @@
+      +package auth

--- a/internal/backend/ui.go
+++ b/internal/backend/ui.go
@@ -111,6 +111,12 @@ func (s *Server) handlePRDetail(w http.ResponseWriter, r *http.Request, owner, r
 		renderCommentBodies(comments)
 		data.Comments = comments
 
+		reviewComments := fetchCached(r.Context(), s.reviewCommentStore, key, func(ctx context.Context) ([]api.ReviewComment, error) {
+			return s.githubClient.ListReviewComments(ctx, fullRepo, number)
+		})
+		renderReviewCommentBodies(reviewComments)
+		data.ReviewComments = reviewComments
+
 	case "commits":
 		data.Commits = fetchCached(r.Context(), s.commitStore, key, func(ctx context.Context) ([]api.PRCommit, error) {
 			return s.githubClient.ListPRCommits(ctx, fullRepo, number)
@@ -349,11 +355,11 @@ func renderReviewCommentBodies(comments []api.ReviewComment) {
 	}
 }
 
-// filterReviewCommentsForFile returns review comments that belong to the given file path.
+// filterReviewCommentsForFile returns non-outdated review comments that belong to the given file path.
 func filterReviewCommentsForFile(comments []api.ReviewComment, path string) []api.ReviewComment {
 	var result []api.ReviewComment
 	for _, c := range comments {
-		if c.Status.Path == path {
+		if c.Status.Path == path && !c.Status.Outdated {
 			result = append(result, c)
 		}
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -350,6 +350,7 @@ type githubReviewComment struct {
 	ID        int        `json:"id"`
 	Body      string     `json:"body"`
 	Path      string     `json:"path"`
+	Position  *int       `json:"position"`
 	Line      int        `json:"line"`
 	Side      string     `json:"side"`
 	HTMLURL   string     `json:"html_url"`
@@ -628,6 +629,7 @@ func (c *Client) ListReviewComments(ctx context.Context, repo string, number int
 				UpdatedAt: gc.UpdatedAt,
 				DiffHunk:  gc.DiffHunk,
 				InReplyTo: gc.InReplyTo,
+				Outdated:  gc.Position == nil,
 			},
 		}
 	}


### PR DESCRIPTION
## Summary
- Detect outdated review comments via GitHub API `position` field (null when code has changed)
- Show all review comments in the **Conversation** tab: non-outdated comments appear expanded, outdated ones are collapsed in a `<details>` element with an "Outdated" badge
- Filter outdated comments out of the **Files changed** tab to keep inline diffs focused on current comments
- Add dark mode support for the new review comment UI elements

Fixes #7

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` all tests pass
- [x] Golden test for conversation tab shows review comments with outdated collapsed
- [x] Golden test for files tab excludes outdated comments
- [ ] Manual verification with a real PR that has outdated review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)