### PR TITLE
Merge PR conversation into a unified timeline

### DIFF
--- a/internal/backend/render_test.go
+++ b/internal/backend/render_test.go
@@ -109,13 +109,12 @@ func runPRGoldenTest(t *testing.T, dir string) {
 				rc := cloneReviewComments(reviewComments)
 				renderReviewCommentBodies(rc)
 				return prDetailData{
-					Owner:          owner,
-					Repo:           repo,
-					Number:         number,
-					ActiveTab:      "conversation",
-					PR:             &pr,
-					Comments:       c,
-					ReviewComments: rc,
+					Owner:     owner,
+					Repo:      repo,
+					Number:    number,
+					ActiveTab: "conversation",
+					PR:        &pr,
+					Timeline:  buildTimeline(c, rc),
 				}
 			},
 		},

--- a/internal/backend/templates.go
+++ b/internal/backend/templates.go
@@ -2,9 +2,42 @@ package backend
 
 import (
 	"html/template"
+	"sort"
 
 	"github.com/justinsb/gitctl/internal/api"
 )
+
+// TimelineEntry represents a single entry in the PR conversation timeline.
+// It wraps either a Comment or a ReviewComment so they can be sorted by time.
+type TimelineEntry struct {
+	// IsReviewComment is true when this entry wraps a ReviewComment.
+	IsReviewComment bool
+	Comment         api.Comment
+	ReviewComment   api.ReviewComment
+	CreatedAt       string
+}
+
+// buildTimeline merges comments and review comments into a single timeline sorted by CreatedAt.
+func buildTimeline(comments []api.Comment, reviewComments []api.ReviewComment) []TimelineEntry {
+	entries := make([]TimelineEntry, 0, len(comments)+len(reviewComments))
+	for _, c := range comments {
+		entries = append(entries, TimelineEntry{
+			Comment:   c,
+			CreatedAt: c.Status.CreatedAt,
+		})
+	}
+	for _, rc := range reviewComments {
+		entries = append(entries, TimelineEntry{
+			IsReviewComment: true,
+			ReviewComment:   rc,
+			CreatedAt:       rc.Status.CreatedAt,
+		})
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].CreatedAt < entries[j].CreatedAt
+	})
+	return entries
+}
 
 // prDetailData holds all data needed to render a PR detail page.
 type prDetailData struct {
@@ -14,6 +47,7 @@ type prDetailData struct {
 	ActiveTab      string
 	PR             *api.PullRequest
 	Comments       []api.Comment
+	Timeline       []TimelineEntry
 	Commits        []api.PRCommit
 	CheckRuns      []api.CheckRun
 	Files          []fileDiffData
@@ -154,52 +188,48 @@ const prDetailTemplateStr = `<!DOCTYPE html>
 <div class="tab-content">
   <div class="markdown-body">{{if .PR.Spec.Body}}{{safeHTML .PR.Spec.Body}}{{else}}<em class="meta">No description provided.</em>{{end}}</div>
   <hr>
-  {{if .Comments}}
-  <h2>{{len .Comments}} comment(s)</h2>
-  {{range .Comments}}
-  <div class="comment">
-    <div class="comment-header">
-      <span class="comment-author">{{.Status.Author}}</span>
-      <span class="comment-date">{{shortDate .Status.CreatedAt}}</span>
-    </div>
-    <div class="markdown-body">{{safeHTML .Spec.Body}}</div>
-  </div>
-  {{end}}
-  {{else}}
-  <p class="meta">No comments yet.</p>
-  {{end}}
-
-  {{if .ReviewComments}}
-  <h2>Review comments</h2>
-  {{range .ReviewComments}}
-  {{if .Status.Outdated}}
+  {{if .Timeline}}
+  {{range .Timeline}}
+  {{if .IsReviewComment}}
+  {{if .ReviewComment.Status.Outdated}}
   <details class="outdated-comment">
     <summary class="outdated-summary">
       <span class="outdated-badge">Outdated</span>
-      <span class="comment-author">{{.Status.Author}}</span> commented on <code>{{.Status.Path}}</code>
-      <span class="comment-date">{{shortDate .Status.CreatedAt}}</span>
+      <span class="comment-author">{{.ReviewComment.Status.Author}}</span> commented on <code>{{.ReviewComment.Status.Path}}</code>
+      <span class="comment-date">{{shortDate .ReviewComment.Status.CreatedAt}}</span>
     </summary>
     <div class="comment">
       <div class="comment-header">
-        <span class="comment-author">{{.Status.Author}}</span>
-        <span class="comment-date">{{shortDate .Status.CreatedAt}}</span>
+        <span class="comment-author">{{.ReviewComment.Status.Author}}</span>
+        <span class="comment-date">{{shortDate .ReviewComment.Status.CreatedAt}}</span>
       </div>
-      <div class="markdown-body">{{safeHTML .Spec.Body}}</div>
+      <div class="markdown-body">{{safeHTML .ReviewComment.Spec.Body}}</div>
     </div>
   </details>
   {{else}}
   <div class="review-comment-conversation">
-    <div class="review-comment-file"><code>{{.Status.Path}}</code>{{if .Status.Line}} line {{.Status.Line}}{{end}}</div>
+    <div class="review-comment-file"><code>{{.ReviewComment.Status.Path}}</code>{{if .ReviewComment.Status.Line}} line {{.ReviewComment.Status.Line}}{{end}}</div>
     <div class="comment">
       <div class="comment-header">
-        <span class="comment-author">{{.Status.Author}}</span>
-        <span class="comment-date">{{shortDate .Status.CreatedAt}}</span>
+        <span class="comment-author">{{.ReviewComment.Status.Author}}</span>
+        <span class="comment-date">{{shortDate .ReviewComment.Status.CreatedAt}}</span>
       </div>
-      <div class="markdown-body">{{safeHTML .Spec.Body}}</div>
+      <div class="markdown-body">{{safeHTML .ReviewComment.Spec.Body}}</div>
     </div>
   </div>
   {{end}}
+  {{else}}
+  <div class="comment">
+    <div class="comment-header">
+      <span class="comment-author">{{.Comment.Status.Author}}</span>
+      <span class="comment-date">{{shortDate .Comment.Status.CreatedAt}}</span>
+    </div>
+    <div class="markdown-body">{{safeHTML .Comment.Spec.Body}}</div>
+  </div>
   {{end}}
+  {{end}}
+  {{else}}
+  <p class="meta">No comments yet.</p>
   {{end}}
 
   <div class="comment-form">

--- a/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
@@ -298,44 +298,6 @@ details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
 </div>
   <hr>
   
-  <h2>2 comment(s)</h2>
-  
-  <div class="comment">
-    <div class="comment-header">
-      <span class="comment-author">bob</span>
-      <span class="comment-date">2026-03-16</span>
-    </div>
-    <div class="markdown-body"><p>Looks good overall! Just a few minor suggestions.</p>
-<p>Can we add rate limiting to the login endpoint?</p>
-</div>
-  </div>
-  
-  <div class="comment">
-    <div class="comment-header">
-      <span class="comment-author">alice</span>
-      <span class="comment-date">2026-03-16</span>
-    </div>
-    <div class="markdown-body"><p>Good point, I'll add that in the next commit.</p>
-</div>
-  </div>
-  
-  
-
-  
-  <h2>Review comments</h2>
-  
-  
-  <div class="review-comment-conversation">
-    <div class="review-comment-file"><code>auth/login.go</code> line 14</div>
-    <div class="comment">
-      <div class="comment-header">
-        <span class="comment-author">bob</span>
-        <span class="comment-date">2026-03-16</span>
-      </div>
-      <div class="markdown-body"><p>Should we add rate limiting here before calling <code>validateCredentials</code>?</p>
-</div>
-    </div>
-  </div>
   
   
   
@@ -354,6 +316,46 @@ details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
 </div>
     </div>
   </details>
+  
+  
+  
+  
+  <div class="comment">
+    <div class="comment-header">
+      <span class="comment-author">bob</span>
+      <span class="comment-date">2026-03-16</span>
+    </div>
+    <div class="markdown-body"><p>Looks good overall! Just a few minor suggestions.</p>
+<p>Can we add rate limiting to the login endpoint?</p>
+</div>
+  </div>
+  
+  
+  
+  
+  <div class="review-comment-conversation">
+    <div class="review-comment-file"><code>auth/login.go</code> line 14</div>
+    <div class="comment">
+      <div class="comment-header">
+        <span class="comment-author">bob</span>
+        <span class="comment-date">2026-03-16</span>
+      </div>
+      <div class="markdown-body"><p>Should we add rate limiting here before calling <code>validateCredentials</code>?</p>
+</div>
+    </div>
+  </div>
+  
+  
+  
+  
+  <div class="comment">
+    <div class="comment-header">
+      <span class="comment-author">alice</span>
+      <span class="comment-date">2026-03-16</span>
+    </div>
+    <div class="markdown-body"><p>Good point, I'll add that in the next commit.</p>
+</div>
+  </div>
   
   
   

--- a/internal/backend/ui.go
+++ b/internal/backend/ui.go
@@ -109,13 +109,13 @@ func (s *Server) handlePRDetail(w http.ResponseWriter, r *http.Request, owner, r
 			return s.githubClient.ListIssueComments(ctx, fullRepo, number)
 		})
 		renderCommentBodies(comments)
-		data.Comments = comments
 
 		reviewComments := fetchCached(r.Context(), s.reviewCommentStore, key, func(ctx context.Context) ([]api.ReviewComment, error) {
 			return s.githubClient.ListReviewComments(ctx, fullRepo, number)
 		})
 		renderReviewCommentBodies(reviewComments)
-		data.ReviewComments = reviewComments
+
+		data.Timeline = buildTimeline(comments, reviewComments)
 
 	case "commits":
 		data.Commits = fetchCached(r.Context(), s.commitStore, key, func(ctx context.Context) ([]api.PRCommit, error) {


### PR DESCRIPTION
## Summary
- Combines PR comments and review comments into a single chronologically-sorted timeline instead of displaying them in separate sections
- Outdated review comments remain collapsed in `<details>` elements
- Adds `TimelineEntry` type and `buildTimeline()` function to merge and sort both comment types by `CreatedAt`

Fixes #9

## Test plan
- [x] Golden tests updated and passing
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual verification: view a PR with interleaved comments and review comments to confirm chronological ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)