### PR TITLE
Show code snippets alongside review comments in conversation view

### DIFF
--- a/internal/backend/templates.go
+++ b/internal/backend/templates.go
@@ -101,6 +101,13 @@ var templateFuncMap = template.FuncMap{
 	"safeHTML": func(s string) template.HTML {
 		return template.HTML(s)
 	},
+	"parseDiffHunk": func(hunk string) []DiffLine {
+		hunks := parsePatch(hunk)
+		if len(hunks) == 0 {
+			return nil
+		}
+		return hunks[0].Lines
+	},
 	"checkIcon": func(status, conclusion string) string {
 		if status != "completed" {
 			return "⏳"
@@ -198,6 +205,19 @@ const prDetailTemplateStr = `<!DOCTYPE html>
       <span class="comment-author">{{.ReviewComment.Status.Author}}</span> commented on <code>{{.ReviewComment.Status.Path}}</code>
       <span class="comment-date">{{shortDate .ReviewComment.Status.CreatedAt}}</span>
     </summary>
+    {{if .ReviewComment.Status.DiffHunk}}
+    <div class="review-comment-snippet">
+      <table class="diff-table">
+      {{range parseDiffHunk .ReviewComment.Status.DiffHunk}}
+      <tr class="diff-line diff-{{.Type}}">
+        <td class="diff-line-num">{{if .OldLine}}{{.OldLine}}{{end}}</td>
+        <td class="diff-line-num">{{if .NewLine}}{{.NewLine}}{{end}}</td>
+        <td class="diff-line-content"><pre>{{.Content}}</pre></td>
+      </tr>
+      {{end}}
+      </table>
+    </div>
+    {{end}}
     <div class="comment">
       <div class="comment-header">
         <span class="comment-author">{{.ReviewComment.Status.Author}}</span>
@@ -209,6 +229,19 @@ const prDetailTemplateStr = `<!DOCTYPE html>
   {{else}}
   <div class="review-comment-conversation">
     <div class="review-comment-file"><code>{{.ReviewComment.Status.Path}}</code>{{if .ReviewComment.Status.Line}} line {{.ReviewComment.Status.Line}}{{end}}</div>
+    {{if .ReviewComment.Status.DiffHunk}}
+    <div class="review-comment-snippet">
+      <table class="diff-table">
+      {{range parseDiffHunk .ReviewComment.Status.DiffHunk}}
+      <tr class="diff-line diff-{{.Type}}">
+        <td class="diff-line-num">{{if .OldLine}}{{.OldLine}}{{end}}</td>
+        <td class="diff-line-num">{{if .NewLine}}{{.NewLine}}{{end}}</td>
+        <td class="diff-line-content"><pre>{{.Content}}</pre></td>
+      </tr>
+      {{end}}
+      </table>
+    </div>
+    {{end}}
     <div class="comment">
       <div class="comment-header">
         <span class="comment-author">{{.ReviewComment.Status.Author}}</span>
@@ -443,6 +476,7 @@ body {
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
     .review-comment-file { color: #9198a1; }
+    .review-comment-snippet { border-color: #30363d; }
     .outdated-summary { color: #9198a1; border-color: #30363d; }
     .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
@@ -607,6 +641,12 @@ a:hover { text-decoration: underline; }
 .review-comment-conversation { margin-bottom: 12px; }
 .review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
 .review-comment-file code { font-size: 12px; }
+.review-comment-snippet {
+    border: 1px solid #d1d9e0; border-radius: 6px 6px 0 0;
+    overflow: hidden; margin-top: 4px;
+}
+.review-comment-snippet + .comment { border-top: 0; border-radius: 0 0 8px 8px; }
+.review-comment-snippet .diff-table { margin: 0; }
 .outdated-comment { margin-bottom: 12px; }
 .outdated-summary {
     cursor: pointer; padding: 8px 12px; font-size: 13px;

--- a/internal/backend/testdata/simple-issue/_issue_detail.html
+++ b/internal/backend/testdata/simple-issue/_issue_detail.html
@@ -47,6 +47,7 @@ body {
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
     .review-comment-file { color: #9198a1; }
+    .review-comment-snippet { border-color: #30363d; }
     .outdated-summary { color: #9198a1; border-color: #30363d; }
     .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
@@ -211,6 +212,12 @@ a:hover { text-decoration: underline; }
 .review-comment-conversation { margin-bottom: 12px; }
 .review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
 .review-comment-file code { font-size: 12px; }
+.review-comment-snippet {
+    border: 1px solid #d1d9e0; border-radius: 6px 6px 0 0;
+    overflow: hidden; margin-top: 4px;
+}
+.review-comment-snippet + .comment { border-top: 0; border-radius: 0 0 8px 8px; }
+.review-comment-snippet .diff-table { margin: 0; }
 .outdated-comment { margin-bottom: 12px; }
 .outdated-summary {
     cursor: pointer; padding: 8px 12px; font-size: 13px;

--- a/internal/backend/testdata/simple-pr/_pr_detail_checks.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_checks.html
@@ -47,6 +47,7 @@ body {
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
     .review-comment-file { color: #9198a1; }
+    .review-comment-snippet { border-color: #30363d; }
     .outdated-summary { color: #9198a1; border-color: #30363d; }
     .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
@@ -211,6 +212,12 @@ a:hover { text-decoration: underline; }
 .review-comment-conversation { margin-bottom: 12px; }
 .review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
 .review-comment-file code { font-size: 12px; }
+.review-comment-snippet {
+    border: 1px solid #d1d9e0; border-radius: 6px 6px 0 0;
+    overflow: hidden; margin-top: 4px;
+}
+.review-comment-snippet + .comment { border-top: 0; border-radius: 0 0 8px 8px; }
+.review-comment-snippet .diff-table { margin: 0; }
 .outdated-comment { margin-bottom: 12px; }
 .outdated-summary {
     cursor: pointer; padding: 8px 12px; font-size: 13px;

--- a/internal/backend/testdata/simple-pr/_pr_detail_commits.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_commits.html
@@ -47,6 +47,7 @@ body {
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
     .review-comment-file { color: #9198a1; }
+    .review-comment-snippet { border-color: #30363d; }
     .outdated-summary { color: #9198a1; border-color: #30363d; }
     .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
@@ -211,6 +212,12 @@ a:hover { text-decoration: underline; }
 .review-comment-conversation { margin-bottom: 12px; }
 .review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
 .review-comment-file code { font-size: 12px; }
+.review-comment-snippet {
+    border: 1px solid #d1d9e0; border-radius: 6px 6px 0 0;
+    overflow: hidden; margin-top: 4px;
+}
+.review-comment-snippet + .comment { border-top: 0; border-radius: 0 0 8px 8px; }
+.review-comment-snippet .diff-table { margin: 0; }
 .outdated-comment { margin-bottom: 12px; }
 .outdated-summary {
     cursor: pointer; padding: 8px 12px; font-size: 13px;

--- a/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
@@ -47,6 +47,7 @@ body {
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
     .review-comment-file { color: #9198a1; }
+    .review-comment-snippet { border-color: #30363d; }
     .outdated-summary { color: #9198a1; border-color: #30363d; }
     .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
@@ -211,6 +212,12 @@ a:hover { text-decoration: underline; }
 .review-comment-conversation { margin-bottom: 12px; }
 .review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
 .review-comment-file code { font-size: 12px; }
+.review-comment-snippet {
+    border: 1px solid #d1d9e0; border-radius: 6px 6px 0 0;
+    overflow: hidden; margin-top: 4px;
+}
+.review-comment-snippet + .comment { border-top: 0; border-radius: 0 0 8px 8px; }
+.review-comment-snippet .diff-table { margin: 0; }
 .outdated-comment { margin-bottom: 12px; }
 .outdated-summary {
     cursor: pointer; padding: 8px 12px; font-size: 13px;
@@ -307,6 +314,25 @@ details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
       <span class="comment-author">carol</span> commented on <code>auth/login.go</code>
       <span class="comment-date">2026-03-15</span>
     </summary>
+    
+    <div class="review-comment-snippet">
+      <table class="diff-table">
+      
+      <tr class="diff-line diff-add">
+        <td class="diff-line-num"></td>
+        <td class="diff-line-num">1</td>
+        <td class="diff-line-content"><pre>package auth</pre></td>
+      </tr>
+      
+      <tr class="diff-line diff-context">
+        <td class="diff-line-num">1</td>
+        <td class="diff-line-num">2</td>
+        <td class="diff-line-content"><pre></pre></td>
+      </tr>
+      
+      </table>
+    </div>
+    
     <div class="comment">
       <div class="comment-header">
         <span class="comment-author">carol</span>
@@ -335,6 +361,25 @@ details[open].outdated-comment > .outdated-summary::before { content: "\25BC"; }
   
   <div class="review-comment-conversation">
     <div class="review-comment-file"><code>auth/login.go</code> line 14</div>
+    
+    <div class="review-comment-snippet">
+      <table class="diff-table">
+      
+      <tr class="diff-line diff-add">
+        <td class="diff-line-num"></td>
+        <td class="diff-line-num">1</td>
+        <td class="diff-line-content"><pre>package auth</pre></td>
+      </tr>
+      
+      <tr class="diff-line diff-context">
+        <td class="diff-line-num">1</td>
+        <td class="diff-line-num">2</td>
+        <td class="diff-line-content"><pre></pre></td>
+      </tr>
+      
+      </table>
+    </div>
+    
     <div class="comment">
       <div class="comment-header">
         <span class="comment-author">bob</span>

--- a/internal/backend/testdata/simple-pr/_pr_detail_files.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_files.html
@@ -47,6 +47,7 @@ body {
     .diff-hunk-header td { background: rgba(56,132,244,0.15); color: #9198a1; }
     .diff-comment { background: rgba(110,118,129,0.15); border-color: #30363d; }
     .review-comment-file { color: #9198a1; }
+    .review-comment-snippet { border-color: #30363d; }
     .outdated-summary { color: #9198a1; border-color: #30363d; }
     .outdated-badge { background: rgba(110,118,129,0.3); color: #9198a1; }
     textarea { background: #161b22; color: #e6edf3; border-color: #30363d; }
@@ -211,6 +212,12 @@ a:hover { text-decoration: underline; }
 .review-comment-conversation { margin-bottom: 12px; }
 .review-comment-file { font-size: 12px; color: #656d76; margin-bottom: 4px; }
 .review-comment-file code { font-size: 12px; }
+.review-comment-snippet {
+    border: 1px solid #d1d9e0; border-radius: 6px 6px 0 0;
+    overflow: hidden; margin-top: 4px;
+}
+.review-comment-snippet + .comment { border-top: 0; border-radius: 0 0 8px 8px; }
+.review-comment-snippet .diff-table { margin: 0; }
 .outdated-comment { margin-bottom: 12px; }
 .outdated-summary {
     cursor: pointer; padding: 8px 12px; font-size: 13px;


### PR DESCRIPTION
## Summary
- Renders the diff hunk (code snippet) above each review comment in the PR conversation tab, providing context for what code the reviewer was commenting on
- Adds a `parseDiffHunk` template helper that reuses the existing `parsePatch` diff parser
- Applies to both active and outdated (collapsed) review comments
- Includes CSS styling with dark mode support

Closes #12

## Test plan
- [x] Golden tests updated and passing (`go test ./internal/backend/`)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual verification: start backend + frontend, navigate to a PR with review comments and confirm code snippets appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)