### PR TITLE
Add dark mode support for HTML detail views

### DIFF
--- a/cmd/gitctl-macos/MarkdownWebView.swift
+++ b/cmd/gitctl-macos/MarkdownWebView.swift
@@ -20,6 +20,7 @@ struct DetailWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero)
         webView.navigationDelegate = context.coordinator
+        webView.underPageBackgroundColor = .windowBackgroundColor
         webView.load(URLRequest(url: url))
         context.coordinator.currentURL = url
         return webView

--- a/internal/backend/templates.go
+++ b/internal/backend/templates.go
@@ -163,6 +163,7 @@ const prDetailTemplateStr = `<!DOCTYPE html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <style>` + pageCSS + `</style>
 </head>
 <body>
@@ -385,6 +386,7 @@ const issueDetailTemplateStr = `<!DOCTYPE html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <style>` + pageCSS + `</style>
 </head>
 <body>
@@ -483,6 +485,15 @@ body {
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
     .files-summary { border-color: #30363d; }
+    .loading { color: #9198a1; }
+    .comment-date { color: #9198a1; }
+    .commit-meta { color: #9198a1; }
+    .check-conclusion { color: #9198a1; }
+    .file-modified { color: #d29922; background: rgba(210,153,34,0.15); }
+    .state-open { color: #3fb950; }
+    .state-closed { color: #f85149; }
+    .comment-form button { background: #238636; }
+    .comment-form button:hover { background: #2ea043; }
 }
 h1 { font-size: 1.5em; font-weight: 600; margin: 8px 0; }
 h2 { font-size: 1.2em; font-weight: 600; margin: 16px 0 8px 0; }

--- a/internal/backend/testdata/simple-issue/_issue_detail.html
+++ b/internal/backend/testdata/simple-issue/_issue_detail.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -54,6 +55,15 @@ body {
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
     .files-summary { border-color: #30363d; }
+    .loading { color: #9198a1; }
+    .comment-date { color: #9198a1; }
+    .commit-meta { color: #9198a1; }
+    .check-conclusion { color: #9198a1; }
+    .file-modified { color: #d29922; background: rgba(210,153,34,0.15); }
+    .state-open { color: #3fb950; }
+    .state-closed { color: #f85149; }
+    .comment-form button { background: #238636; }
+    .comment-form button:hover { background: #2ea043; }
 }
 h1 { font-size: 1.5em; font-weight: 600; margin: 8px 0; }
 h2 { font-size: 1.2em; font-weight: 600; margin: 16px 0 8px 0; }

--- a/internal/backend/testdata/simple-pr/_pr_detail_checks.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_checks.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -54,6 +55,15 @@ body {
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
     .files-summary { border-color: #30363d; }
+    .loading { color: #9198a1; }
+    .comment-date { color: #9198a1; }
+    .commit-meta { color: #9198a1; }
+    .check-conclusion { color: #9198a1; }
+    .file-modified { color: #d29922; background: rgba(210,153,34,0.15); }
+    .state-open { color: #3fb950; }
+    .state-closed { color: #f85149; }
+    .comment-form button { background: #238636; }
+    .comment-form button:hover { background: #2ea043; }
 }
 h1 { font-size: 1.5em; font-weight: 600; margin: 8px 0; }
 h2 { font-size: 1.2em; font-weight: 600; margin: 16px 0 8px 0; }

--- a/internal/backend/testdata/simple-pr/_pr_detail_commits.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_commits.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -54,6 +55,15 @@ body {
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
     .files-summary { border-color: #30363d; }
+    .loading { color: #9198a1; }
+    .comment-date { color: #9198a1; }
+    .commit-meta { color: #9198a1; }
+    .check-conclusion { color: #9198a1; }
+    .file-modified { color: #d29922; background: rgba(210,153,34,0.15); }
+    .state-open { color: #3fb950; }
+    .state-closed { color: #f85149; }
+    .comment-form button { background: #238636; }
+    .comment-form button:hover { background: #2ea043; }
 }
 h1 { font-size: 1.5em; font-weight: 600; margin: 8px 0; }
 h2 { font-size: 1.2em; font-weight: 600; margin: 16px 0 8px 0; }

--- a/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_conversation.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -54,6 +55,15 @@ body {
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
     .files-summary { border-color: #30363d; }
+    .loading { color: #9198a1; }
+    .comment-date { color: #9198a1; }
+    .commit-meta { color: #9198a1; }
+    .check-conclusion { color: #9198a1; }
+    .file-modified { color: #d29922; background: rgba(210,153,34,0.15); }
+    .state-open { color: #3fb950; }
+    .state-closed { color: #f85149; }
+    .comment-form button { background: #238636; }
+    .comment-form button:hover { background: #2ea043; }
 }
 h1 { font-size: 1.5em; font-weight: 600; margin: 8px 0; }
 h2 { font-size: 1.2em; font-weight: 600; margin: 16px 0 8px 0; }

--- a/internal/backend/testdata/simple-pr/_pr_detail_files.html
+++ b/internal/backend/testdata/simple-pr/_pr_detail_files.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -54,6 +55,15 @@ body {
     input[type="text"], input[type="number"] { background: #161b22; color: #e6edf3; border-color: #30363d; }
     .file-diff { border-color: #30363d; }
     .files-summary { border-color: #30363d; }
+    .loading { color: #9198a1; }
+    .comment-date { color: #9198a1; }
+    .commit-meta { color: #9198a1; }
+    .check-conclusion { color: #9198a1; }
+    .file-modified { color: #d29922; background: rgba(210,153,34,0.15); }
+    .state-open { color: #3fb950; }
+    .state-closed { color: #f85149; }
+    .comment-form button { background: #238636; }
+    .comment-form button:hover { background: #2ea043; }
 }
 h1 { font-size: 1.5em; font-weight: 600; margin: 8px 0; }
 h2 { font-size: 1.2em; font-weight: 600; margin: 16px 0 8px 0; }


### PR DESCRIPTION
## Summary

- Add `<meta name="color-scheme" content="light dark">` to both HTML templates so WKWebView and browsers apply system colors to native UI elements (scrollbars, form defaults)
- Fill in missing `@media (prefers-color-scheme: dark)` CSS overrides for secondary text elements: `.loading`, `.comment-date`, `.commit-meta`, `.check-conclusion`, `.file-modified`, `.state-open`, `.state-closed`, and the comment-form submit button
- Set `underPageBackgroundColor = .windowBackgroundColor` on macOS WKWebView to prevent white flash before page content loads in dark mode

Fixes #6

## Test plan
- [ ] Enable dark mode on macOS (System Settings → Appearance → Dark)
- [ ] Start the backend and open a PR detail view — text should be readable on a dark background
- [ ] Verify secondary text (dates, metadata, commit info) appears in a lighter gray rather than being invisible
- [ ] Verify no white flash when navigating to a detail view in dark mode
- [ ] Run `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)