### PR TITLE
Persist custom views across backend restarts

### DIFF
--- a/cmd/gitctl-backend/main.go
+++ b/cmd/gitctl-backend/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -24,35 +23,53 @@ var (
 	tcpAddr      = flag.String("tcp", "127.0.0.1:8484", "TCP address to listen on (empty to disable)")
 	username     = flag.String("username", "justinsb", "GitHub username to sync repositories for")
 	syncInterval = flag.Duration("sync-interval", 5*time.Minute, "How often to poll GitHub for repository updates")
-	dataDir      = flag.String("data-dir", defaultDataDir(), "Directory for persistent data (views, etc.)")
+	dataDir      = flag.String("data-dir", "", "Directory for persistent data (views, etc.); defaults to ~/.config/gitctl")
 )
 
 // defaultDataDir returns the platform default data directory for gitctl.
-func defaultDataDir() string {
-	if home, err := os.UserHomeDir(); err == nil {
-		return home + "/.config/gitctl"
+func defaultDataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	return "/tmp/gitctl-data"
+	return home + "/.config/gitctl", nil
 }
 
 func main() {
+	ctx := context.Background()
+	if err := Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func Run(ctx context.Context) error {
 	flag.Parse()
+
+	dir := *dataDir
+	if dir == "" {
+		var err error
+		dir, err = defaultDataDir()
+		if err != nil {
+			return err
+		}
+	}
 
 	// Remove existing socket if it exists
 	if err := os.RemoveAll(*socketPath); err != nil {
-		log.Fatalf("Failed to remove existing socket: %v", err)
+		return fmt.Errorf("failed to remove existing socket: %w", err)
 	}
 
 	// Create Unix domain socket listener
 	listener, err := net.Listen("unix", *socketPath)
 	if err != nil {
-		log.Fatalf("Failed to listen on %s: %v", *socketPath, err)
+		return fmt.Errorf("failed to listen on %s: %w", *socketPath, err)
 	}
 	defer os.Remove(*socketPath)
 
 	// Make socket accessible to all users
 	if err := os.Chmod(*socketPath, 0666); err != nil {
-		log.Fatalf("Failed to chmod socket: %v", err)
+		return fmt.Errorf("failed to chmod socket: %w", err)
 	}
 
 	// Set up per-resource stores.
@@ -66,22 +83,22 @@ func main() {
 	reviewCommentStore := storage.NewResourceStore[api.ReviewComment]()
 
 	// Set up persistent view store. Create the data directory if needed.
-	if err := os.MkdirAll(*dataDir, 0755); err != nil {
-		log.Fatalf("Failed to create data directory %s: %v", *dataDir, err)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create data directory %s: %w", dir, err)
 	}
-	viewsFile := *dataDir + "/views.json"
-	viewStore, err := storage.NewPersistentCRUDStore[api.View](
+	viewsFile := dir + "/views.json"
+	viewStore, err := storage.NewFileStorage[api.View](
 		func(v api.View) string { return v.Metadata.Name },
 		viewsFile,
 	)
 	if err != nil {
-		log.Fatalf("Failed to initialize view store: %v", err)
+		return fmt.Errorf("failed to initialize view store: %w", err)
 	}
-	log.Printf("View store initialized from %s", viewsFile)
+	fmt.Fprintf(os.Stderr, "View store initialized from %s\n", viewsFile)
 
 	githubClient := github.NewClient()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Start the controllers to poll GitHub and populate storage.
@@ -100,9 +117,9 @@ func main() {
 	// Start Unix socket server.
 	unixServer := &http.Server{Handler: handler}
 	go func() {
-		log.Printf("Backend server listening on %s", *socketPath)
+		fmt.Fprintf(os.Stderr, "Backend server listening on %s\n", *socketPath)
 		if err := unixServer.Serve(listener); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Failed to serve on Unix socket: %v", err)
+			fmt.Fprintf(os.Stderr, "Failed to serve on Unix socket: %v\n", err)
 		}
 	}()
 
@@ -111,13 +128,13 @@ func main() {
 	if *tcpAddr != "" {
 		tcpListener, err := net.Listen("tcp", *tcpAddr)
 		if err != nil {
-			log.Fatalf("Failed to listen on %s: %v", *tcpAddr, err)
+			return fmt.Errorf("failed to listen on %s: %w", *tcpAddr, err)
 		}
 		tcpServer = &http.Server{Handler: handler}
 		go func() {
-			log.Printf("Backend server listening on %s", *tcpAddr)
+			fmt.Fprintf(os.Stderr, "Backend server listening on %s\n", *tcpAddr)
 			if err := tcpServer.Serve(tcpListener); err != nil && err != http.ErrServerClosed {
-				log.Fatalf("Failed to serve on TCP: %v", err)
+				fmt.Fprintf(os.Stderr, "Failed to serve on TCP: %v\n", err)
 			}
 		}()
 	}
@@ -130,11 +147,12 @@ func main() {
 	fmt.Println("\nShutting down server...")
 	cancel()
 	if err := unixServer.Close(); err != nil {
-		log.Printf("Error closing Unix server: %v", err)
+		fmt.Fprintf(os.Stderr, "Error closing Unix server: %v\n", err)
 	}
 	if tcpServer != nil {
 		if err := tcpServer.Close(); err != nil {
-			log.Printf("Error closing TCP server: %v", err)
+			fmt.Fprintf(os.Stderr, "Error closing TCP server: %v\n", err)
 		}
 	}
+	return nil
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -28,7 +28,7 @@ type Server struct {
 	checkRunStore       *storage.ResourceStore[api.CheckRun]
 	prFileStore         *storage.ResourceStore[api.PRFile]
 	reviewCommentStore  *storage.ResourceStore[api.ReviewComment]
-	viewStore           storage.CRUDStoreIface[api.View]
+	viewStore           storage.Storage[api.View]
 	githubClient        *github.Client
 	mux                 *http.ServeMux
 }
@@ -43,7 +43,7 @@ func NewServer(
 	checkRunStore *storage.ResourceStore[api.CheckRun],
 	prFileStore *storage.ResourceStore[api.PRFile],
 	reviewCommentStore *storage.ResourceStore[api.ReviewComment],
-	viewStore storage.CRUDStoreIface[api.View],
+	viewStore storage.Storage[api.View],
 	githubClient *github.Client,
 ) *Server {
 	s := &Server{

--- a/internal/storage/crudstore.go
+++ b/internal/storage/crudstore.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 )
 
-// CRUDStoreIface is the interface implemented by both CRUDStore and PersistentCRUDStore.
-type CRUDStoreIface[T any] interface {
+// Storage is the interface implemented by both CRUDStore and FileStorage.
+type Storage[T any] interface {
 	List(ctx context.Context) ([]T, error)
 	Get(ctx context.Context, name string) (T, bool, error)
 	Create(ctx context.Context, item T) error

--- a/internal/storage/persistentstore.go
+++ b/internal/storage/persistentstore.go
@@ -10,24 +10,24 @@ import (
 	"path/filepath"
 )
 
-// persistedData is the on-disk format for a PersistentCRUDStore.
+// persistedData is the on-disk format for a FileStorage.
 type persistedData[T any] struct {
 	Items []T `json:"items"`
 }
 
-// PersistentCRUDStore wraps CRUDStore with JSON file persistence.
+// FileStorage wraps CRUDStore with JSON file persistence.
 // All items are serialized to a single JSON file after each mutation.
 // On creation, the file is loaded if it exists.
-type PersistentCRUDStore[T any] struct {
+type FileStorage[T any] struct {
 	inner    *CRUDStore[T]
 	filePath string
 }
 
-// NewPersistentCRUDStore creates a PersistentCRUDStore backed by filePath.
+// NewFileStorage creates a FileStorage backed by filePath.
 // If filePath exists, items are loaded from it. The directory must exist.
-func NewPersistentCRUDStore[T any](nameFunc func(T) string, filePath string) (*PersistentCRUDStore[T], error) {
+func NewFileStorage[T any](nameFunc func(T) string, filePath string) (*FileStorage[T], error) {
 	inner := NewCRUDStore[T](nameFunc)
-	s := &PersistentCRUDStore[T]{inner: inner, filePath: filePath}
+	s := &FileStorage[T]{inner: inner, filePath: filePath}
 	if err := s.load(); err != nil {
 		return nil, fmt.Errorf("loading %s: %w", filePath, err)
 	}
@@ -35,7 +35,7 @@ func NewPersistentCRUDStore[T any](nameFunc func(T) string, filePath string) (*P
 }
 
 // load reads items from the JSON file, if it exists.
-func (s *PersistentCRUDStore[T]) load() error {
+func (s *FileStorage[T]) load() error {
 	data, err := os.ReadFile(s.filePath)
 	if os.IsNotExist(err) {
 		return nil // nothing persisted yet
@@ -50,14 +50,14 @@ func (s *PersistentCRUDStore[T]) load() error {
 	for _, item := range pd.Items {
 		if err := s.inner.Create(context.Background(), item); err != nil {
 			// Log and skip duplicates (shouldn't happen with a clean file).
-			log.Printf("PersistentCRUDStore: skipping duplicate item on load: %v", err)
+			log.Printf("FileStorage: skipping duplicate item on load: %v", err)
 		}
 	}
 	return nil
 }
 
 // save writes all current items to the JSON file atomically.
-func (s *PersistentCRUDStore[T]) save(ctx context.Context) error {
+func (s *FileStorage[T]) save(ctx context.Context) error {
 	items, err := s.inner.List(ctx)
 	if err != nil {
 		return err
@@ -87,44 +87,44 @@ func (s *PersistentCRUDStore[T]) save(ctx context.Context) error {
 }
 
 // List returns all items in the store.
-func (s *PersistentCRUDStore[T]) List(ctx context.Context) ([]T, error) {
+func (s *FileStorage[T]) List(ctx context.Context) ([]T, error) {
 	return s.inner.List(ctx)
 }
 
 // Get returns a single item by name.
-func (s *PersistentCRUDStore[T]) Get(ctx context.Context, name string) (T, bool, error) {
+func (s *FileStorage[T]) Get(ctx context.Context, name string) (T, bool, error) {
 	return s.inner.Get(ctx, name)
 }
 
 // Create adds a new item and persists to disk.
-func (s *PersistentCRUDStore[T]) Create(ctx context.Context, item T) error {
+func (s *FileStorage[T]) Create(ctx context.Context, item T) error {
 	if err := s.inner.Create(ctx, item); err != nil {
 		return err
 	}
 	if err := s.save(ctx); err != nil {
-		log.Printf("PersistentCRUDStore: failed to persist after create: %v", err)
+		log.Printf("FileStorage: failed to persist after create: %v", err)
 	}
 	return nil
 }
 
 // Update replaces an existing item and persists to disk.
-func (s *PersistentCRUDStore[T]) Update(ctx context.Context, item T) error {
+func (s *FileStorage[T]) Update(ctx context.Context, item T) error {
 	if err := s.inner.Update(ctx, item); err != nil {
 		return err
 	}
 	if err := s.save(ctx); err != nil {
-		log.Printf("PersistentCRUDStore: failed to persist after update: %v", err)
+		log.Printf("FileStorage: failed to persist after update: %v", err)
 	}
 	return nil
 }
 
 // Delete removes an item and persists to disk.
-func (s *PersistentCRUDStore[T]) Delete(ctx context.Context, name string) error {
+func (s *FileStorage[T]) Delete(ctx context.Context, name string) error {
 	if err := s.inner.Delete(ctx, name); err != nil {
 		return err
 	}
 	if err := s.save(ctx); err != nil {
-		log.Printf("PersistentCRUDStore: failed to persist after delete: %v", err)
+		log.Printf("FileStorage: failed to persist after delete: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

The custom views UI was already implemented (create, list, execute, delete views in the macOS app sidebar), but views were lost whenever the backend restarted because they were stored only in memory.

This PR adds file-backed persistence for views:
- New `PersistentCRUDStore[T]` wraps the in-memory `CRUDStore` with atomic JSON file persistence
- Views are loaded from `~/.config/gitctl/views.json` on startup
- Views are saved atomically (via temp-file rename) after each create, update, or delete
- A `CRUDStoreIface[T]` interface is introduced so the server can accept either store
- Backend accepts a `-data-dir` flag (default: `~/.config/gitctl/`) for the storage path

Fixes #14

## Test plan
- [ ] Start backend, create a view via the macOS app, stop the backend
- [ ] Restart the backend and verify the view reappears in the sidebar
- [ ] Verify `~/.config/gitctl/views.json` is written after creating a view
- [ ] Verify the file is updated after deleting a view
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)