### PR TITLE
Add drag-and-drop GitHub URL support for Views

### DIFF
--- a/cmd/gitctl-macos/ContentView.swift
+++ b/cmd/gitctl-macos/ContentView.swift
@@ -68,6 +68,7 @@ struct ContentView: SwiftUI.View {
     @State private var showCreateView = false
     @State private var viewToEdit: View? = nil
     @State private var isDropTargeted = false
+    @State private var errorMessage: String?
 
     private let client = GitCtlClient()
 
@@ -154,7 +155,8 @@ struct ContentView: SwiftUI.View {
                                         _ = try await client.createView(view: newView)
                                         await loadViews()
                                     } catch {
-                                        // TODO: show error
+                                        print("Error creating view from drop: \(error)")
+                                        await MainActor.run { errorMessage = error.localizedDescription }
                                     }
                                 }
                             }
@@ -170,7 +172,8 @@ struct ContentView: SwiftUI.View {
                                 _ = try await client.createView(view: newView)
                                 await loadViews()
                             } catch {
-                                // TODO: show error
+                                print("Error creating view: \(error)")
+                                errorMessage = error.localizedDescription
                             }
                         }
                     }
@@ -206,6 +209,14 @@ struct ContentView: SwiftUI.View {
                     Text("Select a section")
                         .foregroundStyle(.secondary)
                 }
+            }
+            .alert("Error", isPresented: .init(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK") { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
             }
         }
     }

--- a/cmd/gitctl-macos/ContentView.swift
+++ b/cmd/gitctl-macos/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - Sidebar Selection
 
@@ -58,12 +59,15 @@ enum SelectableItem: Identifiable, Hashable {
     }
 }
 
+// MARK: - Content View
+
 struct ContentView: SwiftUI.View {
     @State private var sidebarSelection: SidebarSelection? = .feed
     @State private var selectedItem: SelectableItem?
     @State private var views: [View] = []
     @State private var showCreateView = false
     @State private var viewToEdit: View? = nil
+    @State private var isDropTargeted = false
 
     private let client = GitCtlClient()
 
@@ -120,10 +124,42 @@ struct ContentView: SwiftUI.View {
                                 }
                             }
                         }
+                        if isDropTargeted {
+                            Label("Drop to add view", systemImage: "plus.circle")
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+                        }
                         Button(action: { showCreateView = true }) {
                             Label("New View", systemImage: "plus")
                         }
                         .foregroundStyle(.secondary)
+                    }
+                    .onDrop(of: [UTType.url], isTargeted: $isDropTargeted) { providers in
+                        for provider in providers {
+                            provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, _ in
+                                guard let data = item as? Data,
+                                      let urlString = String(data: data, encoding: .utf8) else { return }
+                                Task {
+                                    guard let parsed = try? await client.parseGitHubURL(urlString: urlString) else { return }
+                                    let name = parsed.displayName.lowercased()
+                                        .replacingOccurrences(of: " ", with: "-")
+                                        .filter { $0.isLetter || $0.isNumber || $0 == "-" }
+                                    let newView = View(
+                                        apiVersion: "gitctl.justinsb.com/v1alpha1",
+                                        kind: "View",
+                                        metadata: ObjectMeta(name: name),
+                                        spec: ViewSpec(query: parsed.query, displayName: parsed.displayName)
+                                    )
+                                    do {
+                                        _ = try await client.createView(view: newView)
+                                        await loadViews()
+                                    } catch {
+                                        // TODO: show error
+                                    }
+                                }
+                            }
+                        }
+                        return true
                     }
                 }
                 .navigationTitle("gitctl")

--- a/cmd/gitctl-macos/ContentView.swift
+++ b/cmd/gitctl-macos/ContentView.swift
@@ -138,8 +138,16 @@ struct ContentView: SwiftUI.View {
                     .onDrop(of: [UTType.url], isTargeted: $isDropTargeted) { providers in
                         for provider in providers {
                             provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, _ in
-                                guard let data = item as? Data,
-                                      let urlString = String(data: data, encoding: .utf8) else { return }
+                                // macOS may deliver the URL item as NSURL or NSData depending on the drag source.
+                                let urlString: String
+                                if let url = item as? URL {
+                                    urlString = url.absoluteString
+                                } else if let data = item as? Data,
+                                          let s = String(data: data, encoding: .utf8) {
+                                    urlString = s.trimmingCharacters(in: .whitespacesAndNewlines)
+                                } else {
+                                    return
+                                }
                                 Task {
                                     guard let parsed = try? await client.parseGitHubURL(urlString: urlString) else { return }
                                     let name = parsed.displayName.lowercased()

--- a/cmd/gitctl-macos/GitCtlClient.swift
+++ b/cmd/gitctl-macos/GitCtlClient.swift
@@ -99,7 +99,9 @@ class GitCtlClient {
         let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 201 else {
-            throw GitCtlError.badResponse
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let body = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            throw GitCtlError.httpError(statusCode, body)
         }
 
         return try JSONDecoder().decode(View.self, from: data)
@@ -177,11 +179,15 @@ class GitCtlClient {
 
 enum GitCtlError: LocalizedError {
     case badResponse
+    case httpError(Int, String)  // statusCode, responseBody
 
     var errorDescription: String? {
         switch self {
         case .badResponse:
             return "Bad response from backend"
+        case .httpError(let code, let body):
+            let msg = body.isEmpty ? "HTTP \(code)" : "HTTP \(code): \(body)"
+            return "Backend error (\(msg))"
         }
     }
 }


### PR DESCRIPTION
## Summary

- Drag a GitHub URL (pulls or issues page) from Safari/Chrome and drop it onto the **Views** section in the sidebar
- The URL is parsed to extract `owner/repo`, query parameters, and a display name
- A new view is created automatically — no dialog required
- Also adds a **GitHub URL** field to the Create View dialog so users can paste a URL to auto-populate the query and display name fields (consistent with the approach in #21)

Fixes #22

## Test plan
- [ ] Open the macOS app
- [ ] In Safari or Chrome, navigate to a GitHub pulls or issues page (e.g. `https://github.com/kubernetes/kops/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc`)
- [ ] Drag the URL from the browser address bar and drop it onto the "Views" section in the gitctl sidebar
- [ ] Verify a new view is created with the correct query and display name
- [ ] Verify the "Drop to add view" hint appears while dragging over the Views section
- [ ] Open the Create View dialog (+), paste a GitHub URL into the GitHub URL field, and verify Query and Display Name are auto-populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)